### PR TITLE
FreeBoard - Preview 구현

### DIFF
--- a/src/main/java/com/springboot/intelllij/controller/FreeBoardController.java
+++ b/src/main/java/com/springboot/intelllij/controller/FreeBoardController.java
@@ -1,6 +1,7 @@
 package com.springboot.intelllij.controller;
 
 import com.springboot.intelllij.domain.FreeBoardEntity;
+import com.springboot.intelllij.domain.FreeBoardPreview;
 import com.springboot.intelllij.services.FreeBoardService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -17,6 +18,9 @@ public class FreeBoardController {
 
     @GetMapping("/api/free-board")
     public List<FreeBoardEntity>  getFreeBoard() { return freeBoardService.getAllPosts(); }
+
+    @GetMapping("/api/free-board/preview")
+    public List<FreeBoardPreview>  getFreeBoardPreviews() { return freeBoardService.getAllPreviews(); }
 
     @PostMapping(path = "/api/free-board", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody

--- a/src/main/java/com/springboot/intelllij/domain/FreeBoardPreview.java
+++ b/src/main/java/com/springboot/intelllij/domain/FreeBoardPreview.java
@@ -1,0 +1,15 @@
+package com.springboot.intelllij.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class FreeBoardPreview {
+    private Integer id;
+    private Integer user_id;
+    private String title;
+    private String preview;
+}

--- a/src/main/java/com/springboot/intelllij/services/FreeBoardService.java
+++ b/src/main/java/com/springboot/intelllij/services/FreeBoardService.java
@@ -1,6 +1,7 @@
 package com.springboot.intelllij.services;
 
 import com.springboot.intelllij.domain.FreeBoardEntity;
+import com.springboot.intelllij.domain.FreeBoardPreview;
 import com.springboot.intelllij.repository.FreeBoardRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -8,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -21,5 +23,17 @@ public class FreeBoardService {
     public ResponseEntity addPostToFreeBoard(@RequestBody FreeBoardEntity freeBoard) {
         freeBoardRepo.save(freeBoard);
         return ResponseEntity.ok(HttpStatus.OK);
+    }
+
+    public List<FreeBoardPreview> getAllPreviews() {
+        //FIXME - To Const
+        int previewRange = 500;
+        List<FreeBoardPreview> previews = new ArrayList<>();
+        List<FreeBoardEntity> allPosts = freeBoardRepo.findAll();
+        for(FreeBoardEntity post : allPosts) {
+            String content = post.getContent();
+            previews.add(new FreeBoardPreview(post.getId(), post.getUserId(), post.getTitle(), content.substring(0, Math.min(content.length(), previewRange))));
+        }
+        return previews;
     }
 }

--- a/src/main/java/com/springboot/intelllij/services/FreeBoardService.java
+++ b/src/main/java/com/springboot/intelllij/services/FreeBoardService.java
@@ -27,7 +27,7 @@ public class FreeBoardService {
 
     public List<FreeBoardPreview> getAllPreviews() {
         //FIXME - To Const
-        int previewRange = 500;
+        int previewRange = 100;
         List<FreeBoardPreview> previews = new ArrayList<>();
         List<FreeBoardEntity> allPosts = freeBoardRepo.findAll();
         for(FreeBoardEntity post : allPosts) {


### PR DESCRIPTION
- PATH:  /api/free-board/preview
- Parameter : 없음
- Response 
```json
[
  {
    "id": 1,
    "user_id": 0,
    "title": "string",
    "preview": "string"
  },
  {
    "id": 2,
    "user_id": 0,
    "title": "string",
    "preview": "string"
  },
  {
    "id": 3,
    "user_id": 1,
    "title": "post sucks",
    "preview": "123"
  }
]
```

- 현재는 Content의 앞 500글자 까지만 똑 떼서 Preview를 만든느데, 이부분 길이 좀 줄일까? 의견 부탁