### PR TITLE
Add POST apis for reviw / free comments

### DIFF
--- a/src/main/java/com/springboot/intelllij/controller/FreeBoardController.java
+++ b/src/main/java/com/springboot/intelllij/controller/FreeBoardController.java
@@ -1,8 +1,10 @@
 package com.springboot.intelllij.controller;
 
 import com.springboot.intelllij.constant.RESTPath;
+import com.springboot.intelllij.domain.FreeBoardCommentEntity;
 import com.springboot.intelllij.domain.FreeBoardEntity;
 import com.springboot.intelllij.domain.FreeBoardViewEntity;
+import com.springboot.intelllij.services.FreeBoardCommentService;
 import com.springboot.intelllij.services.FreeBoardPreviewService;
 import com.springboot.intelllij.services.FreeBoardService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +25,9 @@ public class FreeBoardController {
     @Autowired
     FreeBoardPreviewService freeBoardPreviewService;
 
+    @Autowired
+    FreeBoardCommentService freeBoardCommentService;
+
     @GetMapping
     public List<FreeBoardViewEntity>  getFreeBoardPreviews() { return freeBoardPreviewService.getAllPreview(); }
 
@@ -35,5 +40,12 @@ public class FreeBoardController {
     @ResponseBody
     public ResponseEntity addPostToFreeBoard(@RequestBody FreeBoardEntity freeBoard) {
         return freeBoardService.addPostToFreeBoard(freeBoard);
+    }
+
+    @PostMapping(value = "/{id}/comments", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseBody
+    public ResponseEntity addCommentToFreeBoard(@PathVariable(name = "id") Integer id, @RequestBody FreeBoardCommentEntity comment) {
+        comment.setPostId(id);
+        return freeBoardCommentService.post(comment);
     }
 }

--- a/src/main/java/com/springboot/intelllij/controller/ReviewBoardController.java
+++ b/src/main/java/com/springboot/intelllij/controller/ReviewBoardController.java
@@ -1,8 +1,12 @@
 package com.springboot.intelllij.controller;
 
 import com.springboot.intelllij.constant.RESTPath;
+import com.springboot.intelllij.domain.FreeBoardCommentEntity;
+import com.springboot.intelllij.domain.ReviewBoardCommentEntity;
 import com.springboot.intelllij.domain.ReviewBoardEntity;
 import com.springboot.intelllij.domain.ReviewBoardViewEntity;
+import com.springboot.intelllij.repository.ReviewBoardCommentRepository;
+import com.springboot.intelllij.services.ReviewBoardCommentService;
 import com.springboot.intelllij.services.ReviewBoardPreviewService;
 import com.springboot.intelllij.services.ReviewBoardService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +27,9 @@ public class ReviewBoardController {
     @Autowired
     ReviewBoardPreviewService reviewBoardPreviewService;
 
+    @Autowired
+    ReviewBoardCommentService reviewBoardCommentService;
+
     @GetMapping
     public List<ReviewBoardViewEntity> getReviewBoardPreview() { return reviewBoardPreviewService.getAllPreview(); }
 
@@ -34,5 +41,12 @@ public class ReviewBoardController {
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity addPostToReviewBoard(@RequestBody ReviewBoardEntity reviewBoard) {
         return reviewBoardService.addPostToReviewBoard(reviewBoard);
+    }
+
+    @PostMapping(value = "/{id}/comments", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseBody
+    public ResponseEntity addCommentToFreeBoard(@PathVariable(name = "id") Integer id, @RequestBody ReviewBoardCommentEntity comment) {
+        comment.setPostId(id);
+        return reviewBoardCommentService.post(comment);
     }
 }

--- a/src/main/java/com/springboot/intelllij/domain/FreeBoardCommentEntity.java
+++ b/src/main/java/com/springboot/intelllij/domain/FreeBoardCommentEntity.java
@@ -6,13 +6,12 @@ import lombok.Setter;
 import javax.persistence.*;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.Date;
 
 @Entity
 @Getter
 @Setter
-@Table(name = "free_board")
-public class FreeBoardEntity {
+@Table(name = "free_board_comment")
+public class FreeBoardCommentEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -22,21 +21,21 @@ public class FreeBoardEntity {
     @Column(name = "account_id")
     private String accountId;
 
-    @Column(name = "title")
-    private String title;
+    @Column(name = "post_id")
+    private Integer postId;
 
     @Column(name = "content")
     private String content;
 
-    @Column(name = "view_cnt")
-    private Integer viewCnt = 0;
-
     @Column(name = "like_cnt")
     private Integer likeCnt = 0;
 
-    @Column(name = "reply_cnt")
-    private Integer replyCnt = 0;
-
     @Column(name = "created_at")
     private ZonedDateTime createdAt = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+
+    @Column(name = "depth")
+    private Integer depth;
+
+    @Column(name = "bundle_id")
+    private Integer bundleId;
 }

--- a/src/main/java/com/springboot/intelllij/domain/ReviewBoardCommentEntity.java
+++ b/src/main/java/com/springboot/intelllij/domain/ReviewBoardCommentEntity.java
@@ -6,37 +6,37 @@ import lombok.Setter;
 import javax.persistence.*;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.Date;
 
 @Entity
 @Getter
 @Setter
-@Table(name = "free_board")
-public class FreeBoardEntity {
+@Table (name = "review_board_comment")
+public class ReviewBoardCommentEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", unique = true, nullable = false)
+    @Column(name = "id")
     private Integer id;
 
     @Column(name = "account_id")
     private String accountId;
 
-    @Column(name = "title")
-    private String title;
+    @Column(name = "post_id")
+    private Integer postId;
 
     @Column(name = "content")
     private String content;
 
-    @Column(name = "view_cnt")
-    private Integer viewCnt = 0;
-
     @Column(name = "like_cnt")
     private Integer likeCnt = 0;
 
-    @Column(name = "reply_cnt")
-    private Integer replyCnt = 0;
-
     @Column(name = "created_at")
     private ZonedDateTime createdAt = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+
+    @Column(name = "depth")
+    private Integer depth;
+
+    @Column(name = "bundle_id")
+    private Integer bundleId;
 }
+

--- a/src/main/java/com/springboot/intelllij/repository/FreeBoardCommentRepository.java
+++ b/src/main/java/com/springboot/intelllij/repository/FreeBoardCommentRepository.java
@@ -1,0 +1,7 @@
+package com.springboot.intelllij.repository;
+
+import com.springboot.intelllij.domain.FreeBoardCommentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FreeBoardCommentRepository extends JpaRepository<FreeBoardCommentEntity, Integer> {
+}

--- a/src/main/java/com/springboot/intelllij/repository/ReviewBoardCommentRepository.java
+++ b/src/main/java/com/springboot/intelllij/repository/ReviewBoardCommentRepository.java
@@ -1,0 +1,7 @@
+package com.springboot.intelllij.repository;
+
+import com.springboot.intelllij.domain.ReviewBoardCommentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewBoardCommentRepository extends JpaRepository<ReviewBoardCommentEntity, Integer> {
+}

--- a/src/main/java/com/springboot/intelllij/services/FreeBoardCommentService.java
+++ b/src/main/java/com/springboot/intelllij/services/FreeBoardCommentService.java
@@ -1,0 +1,21 @@
+package com.springboot.intelllij.services;
+
+import com.springboot.intelllij.domain.FreeBoardCommentEntity;
+import com.springboot.intelllij.repository.FreeBoardCommentRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Service
+public class FreeBoardCommentService {
+
+    @Autowired
+    FreeBoardCommentRepository freeBoardCommentRepo;
+
+    public ResponseEntity post(@RequestBody FreeBoardCommentEntity comment) {
+        freeBoardCommentRepo.save(comment);
+        return ResponseEntity.ok(HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/com/springboot/intelllij/services/FreeBoardCommentService.java
+++ b/src/main/java/com/springboot/intelllij/services/FreeBoardCommentService.java
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.RequestBody;
 
 @Service
 public class FreeBoardCommentService {
@@ -14,7 +13,7 @@ public class FreeBoardCommentService {
     @Autowired
     FreeBoardCommentRepository freeBoardCommentRepo;
 
-    public ResponseEntity post(@RequestBody FreeBoardCommentEntity comment) {
+    public ResponseEntity post( FreeBoardCommentEntity comment) {
         freeBoardCommentRepo.save(comment);
         return ResponseEntity.ok(HttpStatus.CREATED);
     }

--- a/src/main/java/com/springboot/intelllij/services/FreeBoardService.java
+++ b/src/main/java/com/springboot/intelllij/services/FreeBoardService.java
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
 import java.util.Optional;
@@ -19,7 +18,7 @@ public class FreeBoardService {
 
     public List<FreeBoardEntity> getAllPosts() { return freeBoardRepo.findAll(); }
 
-    public ResponseEntity addPostToFreeBoard(@RequestBody FreeBoardEntity freeBoard) {
+    public ResponseEntity addPostToFreeBoard(FreeBoardEntity freeBoard) {
         freeBoardRepo.save(freeBoard);
         return ResponseEntity.ok(HttpStatus.CREATED);
     }

--- a/src/main/java/com/springboot/intelllij/services/ReviewBoardCommentService.java
+++ b/src/main/java/com/springboot/intelllij/services/ReviewBoardCommentService.java
@@ -1,0 +1,22 @@
+package com.springboot.intelllij.services;
+
+import com.springboot.intelllij.domain.FreeBoardCommentEntity;
+import com.springboot.intelllij.domain.ReviewBoardCommentEntity;
+import com.springboot.intelllij.repository.ReviewBoardCommentRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Service
+public class ReviewBoardCommentService {
+
+    @Autowired
+    ReviewBoardCommentRepository reviewBoardCommentRepo;
+
+    public ResponseEntity post(@RequestBody ReviewBoardCommentEntity comment) {
+        reviewBoardCommentRepo.save(comment);
+        return ResponseEntity.ok(HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/com/springboot/intelllij/services/ReviewBoardCommentService.java
+++ b/src/main/java/com/springboot/intelllij/services/ReviewBoardCommentService.java
@@ -1,13 +1,11 @@
 package com.springboot.intelllij.services;
 
-import com.springboot.intelllij.domain.FreeBoardCommentEntity;
 import com.springboot.intelllij.domain.ReviewBoardCommentEntity;
 import com.springboot.intelllij.repository.ReviewBoardCommentRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.RequestBody;
 
 @Service
 public class ReviewBoardCommentService {
@@ -15,7 +13,7 @@ public class ReviewBoardCommentService {
     @Autowired
     ReviewBoardCommentRepository reviewBoardCommentRepo;
 
-    public ResponseEntity post(@RequestBody ReviewBoardCommentEntity comment) {
+    public ResponseEntity post(ReviewBoardCommentEntity comment) {
         reviewBoardCommentRepo.save(comment);
         return ResponseEntity.ok(HttpStatus.CREATED);
     }

--- a/src/main/java/com/springboot/intelllij/services/ReviewBoardService.java
+++ b/src/main/java/com/springboot/intelllij/services/ReviewBoardService.java
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
 import java.util.Optional;
@@ -23,7 +22,7 @@ public class ReviewBoardService {
         return reviewBoardRepo.findById(id);
     }
 
-    public ResponseEntity addPostToReviewBoard(@RequestBody ReviewBoardEntity reviewBoard) {
+    public ResponseEntity addPostToReviewBoard(ReviewBoardEntity reviewBoard) {
         reviewBoardRepo.save(reviewBoard);
         return ResponseEntity.ok(HttpStatus.CREATED);
     }


### PR DESCRIPTION
POST `/api/board/{board-name}/{post-id}/comments` API를 추가함.
POST payload body는 다음과 같음
```json
{
  "accountId": "{사용자 ID}",
  "bundleId": "{댓글이면 없어야 함. 대댓글이면 댓글의 id}",
  "content": "string",
  "depth": "{댓글이면 0, 대댓글이면 1}"
}
```