### PR TITLE
Issue - 31 / 리뷰쓰기에서 쓸모없는 데이터 제거

### DIFF
--- a/src/main/java/com/springboot/intelllij/config/JwtInterceptor.java
+++ b/src/main/java/com/springboot/intelllij/config/JwtInterceptor.java
@@ -2,6 +2,9 @@ package com.springboot.intelllij.config;
 
 import com.springboot.intelllij.constant.AuthConstant;
 import com.springboot.intelllij.utils.TokenUtils;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
@@ -16,8 +19,10 @@ public class JwtInterceptor implements HandlerInterceptor {
         try {
             if(handler != null) {
                 String token = TokenUtils.getTokenFromHeader(header);
-                if(TokenUtils.isValidToken(token))
+                if(TokenUtils.isValidToken(token)) {
+                    SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(TokenUtils.getUserAccount(token),"test"));
                     return true;
+                }
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/com/springboot/intelllij/config/WebMvcConfig.java
+++ b/src/main/java/com/springboot/intelllij/config/WebMvcConfig.java
@@ -17,7 +17,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
         registry.addInterceptor(jwtInterceptor())
                 .excludePathPatterns("/api/user/check/*")
                 .excludePathPatterns("/api/user/signup")
-                .addPathPatterns("/api/*");
+                .addPathPatterns("/api/**");
     }
 
     @Bean

--- a/src/main/java/com/springboot/intelllij/controller/ReviewBoardController.java
+++ b/src/main/java/com/springboot/intelllij/controller/ReviewBoardController.java
@@ -2,6 +2,7 @@ package com.springboot.intelllij.controller;
 
 import com.springboot.intelllij.constant.RESTPath;
 import com.springboot.intelllij.domain.ReviewBoardCommentEntity;
+import com.springboot.intelllij.domain.ReviewBoardDto;
 import com.springboot.intelllij.domain.ReviewBoardEntity;
 import com.springboot.intelllij.domain.ReviewBoardViewEntity;
 import com.springboot.intelllij.services.ReviewBoardCommentService;
@@ -13,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @RestController
@@ -37,8 +39,8 @@ public class ReviewBoardController {
     }
 
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity addPostToReviewBoard(@RequestBody ReviewBoardEntity reviewBoard) {
-        return reviewBoardService.addPostToReviewBoard(reviewBoard);
+    public ResponseEntity addPostToReviewBoard(@RequestBody ReviewBoardDto reviewBoardDto) {
+        return reviewBoardService.addPostToReviewBoard(reviewBoardDto);
     }
 
     @PostMapping(value = "/{id}/comments", consumes = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/com/springboot/intelllij/domain/BoardBaseEntity.java
+++ b/src/main/java/com/springboot/intelllij/domain/BoardBaseEntity.java
@@ -2,6 +2,7 @@ package com.springboot.intelllij.domain;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.Column;
@@ -12,6 +13,7 @@ import java.time.ZonedDateTime;
 @MappedSuperclass
 @Getter
 @Setter
+@NoArgsConstructor
 public class BoardBaseEntity extends BaseEntity {
     @Column(name = "account_id")
     private String account;
@@ -34,4 +36,10 @@ public class BoardBaseEntity extends BaseEntity {
     @Column(name = "created_at")
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
     private ZonedDateTime createdAt = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+
+    public BoardBaseEntity(String account, String title, String content) {
+        this.account = account;
+        this.title = title;
+        this.content = content;
+    }
 }

--- a/src/main/java/com/springboot/intelllij/domain/ReviewBoardDto.java
+++ b/src/main/java/com/springboot/intelllij/domain/ReviewBoardDto.java
@@ -1,0 +1,16 @@
+package com.springboot.intelllij.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewBoardDto {
+    private String content;
+    private Integer lensId;
+    private String title;
+}

--- a/src/main/java/com/springboot/intelllij/domain/ReviewBoardEntity.java
+++ b/src/main/java/com/springboot/intelllij/domain/ReviewBoardEntity.java
@@ -1,6 +1,7 @@
 package com.springboot.intelllij.domain;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.Column;
@@ -10,8 +11,14 @@ import javax.persistence.Table;
 @Entity
 @Getter
 @Setter
+@NoArgsConstructor
 @Table(name = "review_board")
 public class ReviewBoardEntity extends BoardBaseEntity {
     @Column(name = "lens_id")
     private Integer lensId;
+
+    public ReviewBoardEntity(ReviewBoardDto reviewBoardDto, String account) {
+        super(account,reviewBoardDto.getTitle(), reviewBoardDto.getContent());
+        this.lensId = reviewBoardDto.getLensId();
+    }
 }

--- a/src/main/java/com/springboot/intelllij/services/ReviewBoardService.java
+++ b/src/main/java/com/springboot/intelllij/services/ReviewBoardService.java
@@ -1,10 +1,14 @@
 package com.springboot.intelllij.services;
 
+import com.springboot.intelllij.domain.AccountEntity;
+import com.springboot.intelllij.domain.ReviewBoardDto;
 import com.springboot.intelllij.domain.ReviewBoardEntity;
 import com.springboot.intelllij.repository.ReviewBoardRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -22,7 +26,9 @@ public class ReviewBoardService {
         return reviewBoardRepo.findById(id);
     }
 
-    public ResponseEntity addPostToReviewBoard(ReviewBoardEntity reviewBoard) {
+    public ResponseEntity addPostToReviewBoard(ReviewBoardDto reviewBoardDto) {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        ReviewBoardEntity reviewBoard = new ReviewBoardEntity(reviewBoardDto,principal.toString());
         reviewBoardRepo.save(reviewBoard);
         return ResponseEntity.ok(HttpStatus.CREATED);
     }

--- a/src/main/java/com/springboot/intelllij/utils/TokenUtils.java
+++ b/src/main/java/com/springboot/intelllij/utils/TokenUtils.java
@@ -47,6 +47,11 @@ public class TokenUtils {
             return header.split(" ")[1];
     }
 
+    public static String getUserAccount(String token) {
+        Claims claims = getClaimsFromToken(token);
+        return claims.get("id").toString();
+    }
+
     private static Claims getClaimsFromToken(String token) {
         return Jwts.parser().setSigningKey(DatatypeConverter.parseBase64Binary(secretKey))
                 .parseClaimsJws(token).getBody();


### PR DESCRIPTION
- 리뷰 쓰기 스웨거에서 쓸모없는 애들 빼고 필요한 부분만 받도록 변경
    + 이를 위해 리뷰 DTO 만듬 -> DTO를 입력으로 받도록해서 필요한 데이터만 받고 나머진 자동으로 입력되도록
    + Review Entity랑 Base Entity등의 생성자 추가
<img width="1406" alt="스크린샷 2020-11-07 오후 9 53 54" src="https://user-images.githubusercontent.com/11551871/98441776-d2e9df80-2143-11eb-92da-b414caaffa3d.png">


- 놀라운 사실: 그동안 인터셉터 Path 설정이 잘못되어, ```/api/~``` 로 되어있는 애들만 토큰검사가 이뤄졌고, ```/api/board/~``` 와 같이 한뎁서 더내려 가는것은 안됬었음 -> 이를 수정 