### PR TITLE
[Feature] Issue 31 - 특정 댓글의 모든 대댓글 리턴

### DIFF
--- a/src/main/java/com/springboot/intelllij/controller/FreeBoardController.java
+++ b/src/main/java/com/springboot/intelllij/controller/FreeBoardController.java
@@ -65,4 +65,10 @@ public class FreeBoardController {
     public List<FreeBoardCommentEntity> getFreeBoardComment(@PathVariable(name = "id") Integer postId) {
         return freeBoardCommentService.getCommentByPostId(postId);
     }
+
+    @GetMapping(value = "/{id}/comment/{commendId}")
+    public List<FreeBoardCommentEntity> getFreeBoardAllComments(@PathVariable(name = "id") Integer postId,
+                                                            @PathVariable(name = "commendId") Integer commentId) {
+        return freeBoardCommentService.getAllCommentByPostId(postId,commentId);
+    }
 }

--- a/src/main/java/com/springboot/intelllij/exceptions/EntityNotFoundExceptionEnum.java
+++ b/src/main/java/com/springboot/intelllij/exceptions/EntityNotFoundExceptionEnum.java
@@ -10,7 +10,8 @@ public enum EntityNotFoundExceptionEnum {
     LENS_NOT_FOUND(1,"Lens Not Found"),
     REVIEW_BOARD_NOT_FOUND(2,"Review Board Not Found"),
     USER_NOT_FOUND(3,"User Not Found"),
-    POST_NOT_FOUND(4, "Post Not Found")
+    POST_NOT_FOUND(4, "Post Not Found"),
+    COMMENT_NOT_FOUND(4, "Comment Not Found")
     ;
 
     private final int errorCode;

--- a/src/main/java/com/springboot/intelllij/services/FreeBoardCommentService.java
+++ b/src/main/java/com/springboot/intelllij/services/FreeBoardCommentService.java
@@ -1,6 +1,7 @@
 package com.springboot.intelllij.services;
 
 import com.springboot.intelllij.domain.FreeBoardCommentEntity;
+import com.springboot.intelllij.exceptions.NotFoundException;
 import com.springboot.intelllij.repository.FreeBoardCommentRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -10,6 +11,8 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+
+import static com.springboot.intelllij.exceptions.EntityNotFoundExceptionEnum.COMMENT_NOT_FOUND;
 
 @Service
 public class FreeBoardCommentService {
@@ -45,6 +48,22 @@ public class FreeBoardCommentService {
                 resultCommentList.add(commentsOfComment.get(i));
             }
         }
+
+        return resultCommentList;
+    }
+
+    public List<FreeBoardCommentEntity> getAllCommentByPostId(Integer postId, Integer commentId) {
+        FreeBoardCommentEntity originalComment = freeBoardCommentRepo.findByPostIdAndDepth(postId,COMMENT_DEPTH)
+                .stream().filter(freeBoardCommentEntity -> freeBoardCommentEntity.getId().equals(commentId)).findFirst()
+                .orElseThrow(() -> new NotFoundException(COMMENT_NOT_FOUND));
+        List<FreeBoardCommentEntity> commentsOfComment = freeBoardCommentRepo.findByBundleIdAndDepth(originalComment.getId(),COMMENT_OF_COMMENT_DEPTH);
+        List<FreeBoardCommentEntity> resultCommentList = new ArrayList<>();
+
+        resultCommentList.add(originalComment);
+
+        commentsOfComment.forEach(bundle -> {
+            resultCommentList.add(bundle);
+        });
 
         return resultCommentList;
     }


### PR DESCRIPTION
fix https://github.com/wanna-go-home/Issue/issues/31

- /api/boards/free-board/{id}/comment/{id}
- 특정 댓글의 모든 대댓글 리턴
- 블라 대댓글 페이지처럼 리스트의 맨 앞에는 원 댓글, 그 다음엔 그 댓글의 모든 대댓글 리턴하게 함 -> 이렇게 하까? 아님 원 댓글 뺄까? 클라 어느쪽이 편함 @up0617 @rlarlvy153 @seonhee-kim 
- 만들고보니 postId는 안필요하긴 한데 뺄까? 
- result

```json
[
  {
    "id": 3,
    "accountId": "admin@admin.com",
    "postId": 10,
    "content": "However, for a project or package",
    "likeCnt": 0,
    "createdAt": "2020-11-03T23:57:24.872Z",
    "depth": 0,
    "bundleId": 3,
    "bundleSize": 4
  },
  {
    "id": 5,
    "accountId": "admin@admin.com",
    "postId": 10,
    "content": "Comment of Comment 2",
    "likeCnt": 0,
    "createdAt": "2020-11-03T23:57:26.000Z",
    "depth": 1,
    "bundleId": 3,
    "bundleSize": 0
  },
  {
    "id": 6,
    "accountId": "admin@admin.com",
    "postId": 10,
    "content": "Comment of Comment 3",
    "likeCnt": 0,
    "createdAt": "2020-11-03T23:57:27.000Z",
    "depth": 1,
    "bundleId": 3,
    "bundleSize": 0
  },
  {
    "id": 4,
    "accountId": "admin@admin.com",
    "postId": 10,
    "content": "Comment of Comment 1",
    "likeCnt": 0,
    "createdAt": "2020-11-03T23:57:25.000Z",
    "depth": 1,
    "bundleId": 3,
    "bundleSize": 0
  },
  {
    "id": 7,
    "accountId": "admin@admin.com",
    "postId": 10,
    "content": "Comment of Comment 4",
    "likeCnt": 0,
    "createdAt": "2020-11-03T23:57:28.000Z",
    "depth": 1,
    "bundleId": 3,
    "bundleSize": 0
  }
]
```