### PR TITLE
[Feature] Issue 38 - Update & Delete in bundle

### DIFF
--- a/src/main/java/com/springboot/intelllij/controller/FreeBoardController.java
+++ b/src/main/java/com/springboot/intelllij/controller/FreeBoardController.java
@@ -71,4 +71,19 @@ public class FreeBoardController {
                                                             @PathVariable(name = "commendId") Integer commentId) {
         return freeBoardCommentService.getAllCommentByPostId(postId,commentId);
     }
+
+    @PutMapping(value = "/{id}/comment/{commendId}", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public FreeBoardCommentEntity updateFreeBoardCommentById(
+            @PathVariable(name = "id") Integer postId,
+            @PathVariable(name = "commendId") Integer commentId,
+            @RequestBody String content) {
+        return freeBoardCommentService.updateComment(postId, commentId, content);
+    }
+
+    @DeleteMapping(value = "/{id}/comment/{commendId}")
+    public ResponseEntity deleteFreeBoardCommentById(
+            @PathVariable(name = "id") Integer postId,
+            @PathVariable(name = "commendId") Integer commentId) {
+        return freeBoardCommentService.deleteComment(postId, commentId);
+    }
 }

--- a/src/main/java/com/springboot/intelllij/services/FreeBoardCommentService.java
+++ b/src/main/java/com/springboot/intelllij/services/FreeBoardCommentService.java
@@ -67,4 +67,17 @@ public class FreeBoardCommentService {
 
         return resultCommentList;
     }
+
+    public FreeBoardCommentEntity updateComment(Integer postId, Integer commentId, String content) {
+        FreeBoardCommentEntity originalComment = freeBoardCommentRepo.findById(commentId).orElseThrow(() -> new NotFoundException(COMMENT_NOT_FOUND));
+
+        originalComment.setContent(content);
+
+        return freeBoardCommentRepo.save(originalComment);
+    }
+
+    public ResponseEntity deleteComment(Integer postId, Integer commentId) {
+        freeBoardCommentRepo.deleteById(commentId);
+        return ResponseEntity.ok(HttpStatus.OK);
+    }
 }


### PR DESCRIPTION
fix https://github.com/wanna-go-home/Issue/issues/38

자유게시판 댓글 대댓글 업데이트 / 삭제 추가

1. 댓글 대댓글 업데이트
- PUT /api/boards/free-board/{id}/comment/{commendId}
- 업데이트니까 업데이트할 댓글 내용만 입력받음
![image](https://user-images.githubusercontent.com/11551871/102001666-1681cb80-3d38-11eb-8cc3-9041f148798e.png)

2. 댓글 대댓글 삭제
- DELETE /api/boards/free-board/{id}/comment/{commendId}
![image](https://user-images.githubusercontent.com/11551871/102001688-3b763e80-3d38-11eb-8a6e-f50f9c8d4e75.png)


- 내부 구현상 POST ID는 필요가 없지만, 저번에 대댓글에서 냄겨달라고 해서 남겨는 둠
