### PR TITLE
[Hotfix] Modify Post APIs - Freeboard / Freeboard Comment

### DIFF
--- a/src/main/java/com/springboot/intelllij/controller/FreeBoardController.java
+++ b/src/main/java/com/springboot/intelllij/controller/FreeBoardController.java
@@ -1,10 +1,7 @@
 package com.springboot.intelllij.controller;
 
 import com.springboot.intelllij.constant.RESTPath;
-import com.springboot.intelllij.domain.BoardUpdateDTO;
-import com.springboot.intelllij.domain.FreeBoardCommentEntity;
-import com.springboot.intelllij.domain.FreeBoardEntity;
-import com.springboot.intelllij.domain.FreeBoardViewEntity;
+import com.springboot.intelllij.domain.*;
 import com.springboot.intelllij.services.FreeBoardCommentService;
 import com.springboot.intelllij.services.FreeBoardPreviewService;
 import com.springboot.intelllij.services.FreeBoardService;
@@ -50,15 +47,14 @@ public class FreeBoardController {
 
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
-    public ResponseEntity addPostToFreeBoard(@RequestBody FreeBoardEntity freeBoard) {
+    public ResponseEntity addPostToFreeBoard(@RequestBody BoardUpdateDTO freeBoard) {
         return freeBoardService.addPostToFreeBoard(freeBoard);
     }
 
     @PostMapping(value = "/{id}/comments", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
-    public ResponseEntity addCommentToFreeBoard(@PathVariable(name = "id") Integer id, @RequestBody FreeBoardCommentEntity comment) {
-        comment.setPostId(id);
-        return freeBoardCommentService.post(comment);
+    public ResponseEntity addCommentToFreeBoard(@PathVariable(name = "id") Integer id, @RequestBody CommentDTO comment) {
+        return freeBoardCommentService.post(id, comment);
     }
 
     @GetMapping(value = "/{id}/comments")

--- a/src/main/java/com/springboot/intelllij/domain/CommentDTO.java
+++ b/src/main/java/com/springboot/intelllij/domain/CommentDTO.java
@@ -13,6 +13,5 @@ import java.util.Optional;
 @NoArgsConstructor
 public class CommentDTO {
     Integer bundleId;
-    Integer depth;
     String content;
 }

--- a/src/main/java/com/springboot/intelllij/domain/CommentDTO.java
+++ b/src/main/java/com/springboot/intelllij/domain/CommentDTO.java
@@ -1,0 +1,18 @@
+package com.springboot.intelllij.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Optional;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommentDTO {
+    Integer bundleId;
+    Integer depth;
+    String content;
+}

--- a/src/main/java/com/springboot/intelllij/services/FreeBoardCommentService.java
+++ b/src/main/java/com/springboot/intelllij/services/FreeBoardCommentService.java
@@ -35,13 +35,13 @@ public class FreeBoardCommentService {
 
         commentEntity.setContent(comment.getContent());
         commentEntity.setPostId(postId);
-        commentEntity.setDepth(comment.getDepth());
 
         commentEntity.setCreatedAt(ZonedDateTime.now());
         commentEntity.setAccountId(user);
 
         if(comment.getBundleId() != null) {
             commentEntity.setBundleId(comment.getBundleId());
+            commentEntity.setDepth(COMMENT_OF_COMMENT_DEPTH);
             freeBoardCommentRepo.save(commentEntity);
         } else {
             FreeBoardCommentEntity savedEntity = freeBoardCommentRepo.save(commentEntity);

--- a/src/main/java/com/springboot/intelllij/services/FreeBoardService.java
+++ b/src/main/java/com/springboot/intelllij/services/FreeBoardService.java
@@ -1,5 +1,6 @@
 package com.springboot.intelllij.services;
 
+import com.springboot.intelllij.domain.BoardUpdateDTO;
 import com.springboot.intelllij.domain.FreeBoardEntity;
 import com.springboot.intelllij.domain.FreeBoardViewEntity;
 import com.springboot.intelllij.exceptions.NotFoundException;
@@ -9,9 +10,11 @@ import com.springboot.intelllij.repository.FreeBoardRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -30,8 +33,17 @@ public class FreeBoardService {
 
     public List<FreeBoardEntity> getAllPosts() { return freeBoardRepo.findAll(); }
 
-    public ResponseEntity addPostToFreeBoard(FreeBoardEntity freeBoard) {
-        freeBoardRepo.save(freeBoard);
+    public ResponseEntity addPostToFreeBoard(BoardUpdateDTO freeBoard) {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String user = principal.toString();
+        FreeBoardEntity entity = new FreeBoardEntity();
+
+        entity.setAccount(user);
+        entity.setContent(freeBoard.getContent());
+        entity.setCreatedAt(ZonedDateTime.now());
+        entity.setTitle(freeBoard.getTitle());
+
+        freeBoardRepo.save(entity);
         return ResponseEntity.ok(HttpStatus.CREATED);
     }
 


### PR DESCRIPTION
FreeBoard의 글쓰기 / 댓글&대댓글 쓰기 Post 수정

- 글쓰기
![image](https://user-images.githubusercontent.com/11551871/102009971-61becd00-3d7e-11eb-851f-67e35099634b.png)

- 댓글 / 대댓글 쓰기 [ 수정됨 ]
![image](https://user-images.githubusercontent.com/11551871/102010163-aa2aba80-3d7f-11eb-9ab8-16201df7ca3a.png)

    * 이쪽이 약간 애매한게 댓글 / 대댓글을 같은 API로 입력 받게 했음
    * 그래서 걍 댓글은 bundleId 입력 안하고 컨텐츠만 넣으면 댓글로 됨
    * 대댓글은 bundleId 입력하면 알아서 depth는 1로 되서 대댓글이 될것