### PR TITLE
[Issue - 69] Sort Board Content

### DIFF
--- a/src/main/java/com/springboot/intelllij/services/FreeBoardPreviewService.java
+++ b/src/main/java/com/springboot/intelllij/services/FreeBoardPreviewService.java
@@ -2,6 +2,7 @@ package com.springboot.intelllij.services;
 
 import com.springboot.intelllij.domain.FreeBoardViewEntity;
 import com.springboot.intelllij.repository.FreeBoardPreviewRepository;
+import com.springboot.intelllij.utils.BoardComparator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -14,11 +15,21 @@ public class FreeBoardPreviewService {
     @Autowired
     FreeBoardPreviewRepository freeBoardPreviewRepo;
 
-    public List<FreeBoardViewEntity> getAllPreview() { return freeBoardPreviewRepo.findAll(); }
+    public List<FreeBoardViewEntity> getAllPreview() {
+        List<FreeBoardViewEntity> result = freeBoardPreviewRepo.findAll();
+
+        result.sort(new BoardComparator());
+
+        return result;
+    }
 
     public List<FreeBoardViewEntity> getMyAllPreview() {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         String user = principal.toString();
-        return freeBoardPreviewRepo.findByEmail(user);
+        List<FreeBoardViewEntity> result = freeBoardPreviewRepo.findByEmail(user);
+
+        result.sort(new BoardComparator());
+
+        return result;
     }
 }

--- a/src/main/java/com/springboot/intelllij/services/ReviewBoardPreviewService.java
+++ b/src/main/java/com/springboot/intelllij/services/ReviewBoardPreviewService.java
@@ -2,10 +2,12 @@ package com.springboot.intelllij.services;
 
 import com.springboot.intelllij.domain.ReviewBoardViewEntity;
 import com.springboot.intelllij.repository.ReviewBoardPreviewRepository;
+import com.springboot.intelllij.utils.BoardComparator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
+import java.util.Comparator;
 import java.util.List;
 
 @Service
@@ -14,11 +16,21 @@ public class ReviewBoardPreviewService {
     @Autowired
     ReviewBoardPreviewRepository reviewBoardPreviewRepo;
 
-    public List<ReviewBoardViewEntity> getAllPreview() { return reviewBoardPreviewRepo.findAll(); }
+    public List<ReviewBoardViewEntity> getAllPreview() {
+        List<ReviewBoardViewEntity> result = reviewBoardPreviewRepo.findAll();
+
+        result.sort(new BoardComparator());
+
+        return result;
+    }
 
     public List<ReviewBoardViewEntity> getMyAllPreview() {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         String user = principal.toString();
-        return reviewBoardPreviewRepo.findByEmail(user);
+        List<ReviewBoardViewEntity> result = reviewBoardPreviewRepo.findByEmail(user);
+
+        result.sort(new BoardComparator());
+
+        return result;
     }
 }

--- a/src/main/java/com/springboot/intelllij/utils/BoardComparator.java
+++ b/src/main/java/com/springboot/intelllij/utils/BoardComparator.java
@@ -1,0 +1,15 @@
+package com.springboot.intelllij.utils;
+
+import com.springboot.intelllij.domain.BoardBaseEntity;
+
+import java.util.Comparator;
+
+public class BoardComparator implements Comparator<BoardBaseEntity> {
+
+    @Override
+    public int compare(BoardBaseEntity o1, BoardBaseEntity o2) {
+        if(o1.getCreatedAt().isBefore(o2.getCreatedAt())) return 1;
+        else if (o2.getCreatedAt().isBefore(o1.getCreatedAt())) return -1;
+        else return 0;
+    }
+}


### PR DESCRIPTION
fix https://github.com/wanna-go-home/Issue/issues/69

얍동의 의심대로 자유게시판 뿐만아니라 리뷰게시판도 정렬 순서가 반대였음 ㅎ_ㅎ
그래서 둘다 한꺼번에 정렬 할 수있는 Comparator 하나 만들어서 구현