### PR TITLE
[Hotfix] Issue-85, increase reply cnt

### DIFF
--- a/src/main/java/com/springboot/intelllij/domain/BoardBaseEntity.java
+++ b/src/main/java/com/springboot/intelllij/domain/BoardBaseEntity.java
@@ -42,4 +42,8 @@ public class BoardBaseEntity extends BaseEntity {
         this.title = title;
         this.content = content;
     }
+
+    public void increaseReplyCnt() {
+        this.replyCnt++;
+    }
 }

--- a/src/main/java/com/springboot/intelllij/services/FreeBoardCommentService.java
+++ b/src/main/java/com/springboot/intelllij/services/FreeBoardCommentService.java
@@ -2,27 +2,32 @@ package com.springboot.intelllij.services;
 
 import com.springboot.intelllij.domain.CommentDTO;
 import com.springboot.intelllij.domain.FreeBoardCommentEntity;
+import com.springboot.intelllij.domain.FreeBoardEntity;
 import com.springboot.intelllij.exceptions.NotFoundException;
 import com.springboot.intelllij.repository.FreeBoardCommentRepository;
+import com.springboot.intelllij.repository.FreeBoardRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
-import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
 import static com.springboot.intelllij.exceptions.EntityNotFoundExceptionEnum.COMMENT_NOT_FOUND;
+import static com.springboot.intelllij.exceptions.EntityNotFoundExceptionEnum.POST_NOT_FOUND;
 
 @Service
 public class FreeBoardCommentService {
 
     @Autowired
     FreeBoardCommentRepository freeBoardCommentRepo;
+
+    @Autowired
+    FreeBoardRepository freeBoardRepo;
 
     private final int COMMENT_MAX = 3;
     private final int COMMENT_DEPTH = 0;
@@ -32,6 +37,7 @@ public class FreeBoardCommentService {
         FreeBoardCommentEntity commentEntity = new FreeBoardCommentEntity();
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         String user = principal.toString();
+        FreeBoardEntity article = freeBoardRepo.findById(postId).orElseThrow(() -> new NotFoundException(POST_NOT_FOUND));
 
         commentEntity.setContent(comment.getContent());
         commentEntity.setPostId(postId);
@@ -53,6 +59,10 @@ public class FreeBoardCommentService {
             savedEntity.setBundleId(savedEntity.getId());
             freeBoardCommentRepo.save(savedEntity);
         }
+
+        article.increaseReplyCnt();
+        freeBoardRepo.save(article);
+
         return ResponseEntity.ok(HttpStatus.CREATED);
     }
 

--- a/src/main/java/com/springboot/intelllij/services/ReviewBoardCommentService.java
+++ b/src/main/java/com/springboot/intelllij/services/ReviewBoardCommentService.java
@@ -3,8 +3,10 @@ package com.springboot.intelllij.services;
 import com.springboot.intelllij.domain.CommentDTO;
 import com.springboot.intelllij.domain.FreeBoardCommentEntity;
 import com.springboot.intelllij.domain.ReviewBoardCommentEntity;
+import com.springboot.intelllij.domain.ReviewBoardEntity;
 import com.springboot.intelllij.exceptions.NotFoundException;
 import com.springboot.intelllij.repository.ReviewBoardCommentRepository;
+import com.springboot.intelllij.repository.ReviewBoardRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,12 +19,16 @@ import java.util.Comparator;
 import java.util.List;
 
 import static com.springboot.intelllij.exceptions.EntityNotFoundExceptionEnum.COMMENT_NOT_FOUND;
+import static com.springboot.intelllij.exceptions.EntityNotFoundExceptionEnum.POST_NOT_FOUND;
 
 @Service
 public class ReviewBoardCommentService {
 
     @Autowired
     ReviewBoardCommentRepository reviewBoardCommentRepo;
+
+    @Autowired
+    ReviewBoardRepository reviewBoardRepo;
 
     private final int COMMENT_MAX = 3;
     private final int COMMENT_DEPTH = 0;
@@ -32,6 +38,7 @@ public class ReviewBoardCommentService {
         ReviewBoardCommentEntity commentEntity = new ReviewBoardCommentEntity();
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         String user = principal.toString();
+        ReviewBoardEntity review = reviewBoardRepo.findById(postId).orElseThrow(() -> new NotFoundException(POST_NOT_FOUND));
 
         commentEntity.setContent(comment.getContent());
         commentEntity.setPostId(postId);
@@ -53,6 +60,10 @@ public class ReviewBoardCommentService {
             savedEntity.setBundleId(savedEntity.getId());
             reviewBoardCommentRepo.save(savedEntity);
         }
+
+        review.increaseReplyCnt();
+        reviewBoardRepo.save(review);
+        
         return ResponseEntity.ok(HttpStatus.CREATED);
     }
 


### PR DESCRIPTION
fix https://github.com/wanna-go-home/Issue/issues/85

- 리뷰, 아티클 모두 댓글달때 댓글 카운트 증가시키는게 빠져있었음. 수정함
- 기존에 들어있는값도 수정하려 했지만, 아티클 코멘트가 너무많아 걍 냅둠 ㅎㅎ
- 코드가 슬슬 구조가 거의 비슷해서 어떻게 하면 추상화 시킬수있을지 고민해보겠음