### PR TITLE
[Hotfix] Issue-84, add nickname in comment

### DIFF
--- a/src/main/java/com/springboot/intelllij/controller/FreeBoardController.java
+++ b/src/main/java/com/springboot/intelllij/controller/FreeBoardController.java
@@ -11,7 +11,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Optional;
 
 @RestController
 @RequestMapping(RESTPath.FREE_BOARD)
@@ -53,17 +52,17 @@ public class FreeBoardController {
 
     @PostMapping(value = "/{id}/comments", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
-    public ResponseEntity addCommentToFreeBoard(@PathVariable(name = "id") Integer id, @RequestBody CommentDTO comment) {
+    public ResponseEntity addCommentToFreeBoard(@PathVariable(name = "id") Integer id, @RequestBody CommentInputDTO comment) {
         return freeBoardCommentService.post(id, comment);
     }
 
     @GetMapping(value = "/{id}/comments")
-    public List<FreeBoardCommentEntity> getFreeBoardComment(@PathVariable(name = "id") Integer postId) {
+    public List<CommentOutputDTO> getFreeBoardComment(@PathVariable(name = "id") Integer postId) {
         return freeBoardCommentService.getCommentByPostId(postId);
     }
 
     @GetMapping(value = "/{id}/comment/{commendId}")
-    public List<FreeBoardCommentEntity> getFreeBoardAllComments(@PathVariable(name = "id") Integer postId,
+    public List<CommentOutputDTO> getFreeBoardAllComments(@PathVariable(name = "id") Integer postId,
                                                             @PathVariable(name = "commendId") Integer commentId) {
         return freeBoardCommentService.getAllCommentByPostId(postId,commentId);
     }

--- a/src/main/java/com/springboot/intelllij/controller/ReviewBoardController.java
+++ b/src/main/java/com/springboot/intelllij/controller/ReviewBoardController.java
@@ -51,17 +51,17 @@ public class ReviewBoardController {
 
     @PostMapping(value = "/{id}/comments", consumes = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
-    public ResponseEntity addCommentToFreeBoard(@PathVariable(name = "id") Integer id, @RequestBody CommentDTO comment) {
+    public ResponseEntity addCommentToFreeBoard(@PathVariable(name = "id") Integer id, @RequestBody CommentInputDTO comment) {
         return reviewBoardCommentService.post(id, comment);
     }
 
     @GetMapping(value = "/{id}/comments")
-    public List<ReviewBoardCommentEntity> getReviewBoardComment(@PathVariable(name = "id") Integer postId) {
+    public List<CommentOutputDTO> getReviewBoardComment(@PathVariable(name = "id") Integer postId) {
         return reviewBoardCommentService.getCommentByPostId(postId);
     }
 
     @GetMapping(value = "/{id}/comment/{commendId}")
-    public List<ReviewBoardCommentEntity> getReviewBoardAllComments(@PathVariable(name = "id") Integer postId,
+    public List<CommentOutputDTO> getReviewBoardAllComments(@PathVariable(name = "id") Integer postId,
                                                                 @PathVariable(name = "commendId") Integer commentId) {
         return reviewBoardCommentService.getAllCommentByPostId(postId,commentId);
     }

--- a/src/main/java/com/springboot/intelllij/domain/CommentBaseEntity.java
+++ b/src/main/java/com/springboot/intelllij/domain/CommentBaseEntity.java
@@ -2,16 +2,19 @@ package com.springboot.intelllij.domain;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;
+import javax.xml.stream.events.Comment;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 @MappedSuperclass
 @Getter
 @Setter
+@NoArgsConstructor
 public class CommentBaseEntity extends BaseEntity {
     @Column(name = "account_id")
     private String email;
@@ -40,5 +43,16 @@ public class CommentBaseEntity extends BaseEntity {
 
     public void increaseBundleSize() {
         this.bundleSize++;
+    }
+
+    public CommentBaseEntity(CommentBaseEntity commentBase) {
+        this.email = commentBase.getEmail();
+        this.postId = commentBase.getPostId();
+        this.content = commentBase.getContent();
+        this.likeCnt = commentBase.getLikeCnt();
+        this.createdAt = commentBase.getCreatedAt();
+        this.depth = commentBase.getDepth();
+        this.bundleId = commentBase.getBundleId();
+        this.bundleSize = commentBase.getBundleSize();
     }
 }

--- a/src/main/java/com/springboot/intelllij/domain/CommentInputDTO.java
+++ b/src/main/java/com/springboot/intelllij/domain/CommentInputDTO.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class CommentDTO {
+public class CommentInputDTO {
     Integer bundleId;
     String content;
 }

--- a/src/main/java/com/springboot/intelllij/domain/CommentOutputDTO.java
+++ b/src/main/java/com/springboot/intelllij/domain/CommentOutputDTO.java
@@ -1,0 +1,22 @@
+package com.springboot.intelllij.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CommentOutputDTO extends CommentBaseEntity {
+    private String nickname;
+
+    public CommentOutputDTO(FreeBoardCommentEntity commentEntity, String nickname) {
+        super((CommentBaseEntity)commentEntity);
+        this.nickname = nickname;
+    }
+
+    public CommentOutputDTO(ReviewBoardCommentEntity commentEntity, String nickname) {
+        super((CommentBaseEntity)commentEntity);
+        this.nickname = nickname;
+    }
+}

--- a/src/main/java/com/springboot/intelllij/domain/FreeBoardCommentEntity.java
+++ b/src/main/java/com/springboot/intelllij/domain/FreeBoardCommentEntity.java
@@ -1,6 +1,7 @@
 package com.springboot.intelllij.domain;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.Column;
@@ -10,7 +11,7 @@ import javax.persistence.Table;
 @Entity
 @Getter
 @Setter
+@NoArgsConstructor
 @Table(name = "free_board_comment")
 public class FreeBoardCommentEntity extends CommentBaseEntity {
-
 }

--- a/src/main/java/com/springboot/intelllij/domain/ReviewBoardCommentEntity.java
+++ b/src/main/java/com/springboot/intelllij/domain/ReviewBoardCommentEntity.java
@@ -1,6 +1,8 @@
 package com.springboot.intelllij.domain;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.Entity;
@@ -10,6 +12,7 @@ import javax.persistence.Table;
 @Getter
 @Setter
 @Table (name = "review_board_comment")
+@NoArgsConstructor
 public class ReviewBoardCommentEntity extends CommentBaseEntity {
 }
 

--- a/src/main/java/com/springboot/intelllij/services/AccountService.java
+++ b/src/main/java/com/springboot/intelllij/services/AccountService.java
@@ -4,6 +4,7 @@ import com.springboot.intelllij.domain.*;
 import com.springboot.intelllij.exceptions.NotFoundException;
 import com.springboot.intelllij.repository.*;
 import com.springboot.intelllij.utils.StringValidationUtils;
+import com.springboot.intelllij.utils.UserUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -36,8 +37,7 @@ public class AccountService {
     public List<AccountEntity> getAllUsers() { return userRepo.findAll(); }
 
     public ResponseEntity deleteUser() {
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String user = principal.toString();
+        String user = UserUtils.getUserStringFromSecurityContextHolder();
         userRepo.deleteById(user);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
@@ -79,9 +79,9 @@ public class AccountService {
 
     public UserInfoDTO getUserInfo() {
         UserInfoDTO userInfo = new UserInfoDTO();
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String user = principal.toString();
-        AccountEntity account = userRepo.findById(user).orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
+        AccountEntity account = UserUtils.getUserEntity();
+        String user = account.getAccountEmail();
+
         List<ReviewBoardEntity> reviewBoardEntities = reviewRepo.findByEmail(user);
         List<FreeBoardEntity> freeBoardEntities = freeRepo.findByEmail(user);
         List<ReviewBoardCommentEntity> reviewBoardCommentEntities = reviewCOmmentRepo.findByEmail(user);

--- a/src/main/java/com/springboot/intelllij/services/FreeBoardCommentService.java
+++ b/src/main/java/com/springboot/intelllij/services/FreeBoardCommentService.java
@@ -1,16 +1,17 @@
 package com.springboot.intelllij.services;
 
-import com.springboot.intelllij.domain.CommentDTO;
+import com.springboot.intelllij.domain.AccountEntity;
+import com.springboot.intelllij.domain.CommentInputDTO;
+import com.springboot.intelllij.domain.CommentOutputDTO;
 import com.springboot.intelllij.domain.FreeBoardCommentEntity;
 import com.springboot.intelllij.exceptions.NotFoundException;
 import com.springboot.intelllij.repository.FreeBoardCommentRepository;
+import com.springboot.intelllij.utils.UserUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
-import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -26,12 +27,11 @@ public class FreeBoardCommentService {
 
     private final int COMMENT_MAX = 3;
     private final int COMMENT_DEPTH = 0;
-    private final int COMMENT_OF_COMMENT_DEPTH = 1;
+    private final int CHILD_COMMENT_DEPTH = 1;
 
-    public ResponseEntity post(Integer postId, CommentDTO comment) {
+    public ResponseEntity post(Integer postId, CommentInputDTO comment) {
         FreeBoardCommentEntity commentEntity = new FreeBoardCommentEntity();
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String user = principal.toString();
+        String user = UserUtils.getUserStringFromSecurityContextHolder();
 
         commentEntity.setContent(comment.getContent());
         commentEntity.setPostId(postId);
@@ -41,7 +41,7 @@ public class FreeBoardCommentService {
 
         if(comment.getBundleId() != null) {
             commentEntity.setBundleId(comment.getBundleId());
-            commentEntity.setDepth(COMMENT_OF_COMMENT_DEPTH);
+            commentEntity.setDepth(CHILD_COMMENT_DEPTH);
             freeBoardCommentRepo.save(commentEntity);
 
             FreeBoardCommentEntity parentEntity = freeBoardCommentRepo.findById(comment.getBundleId())
@@ -56,40 +56,43 @@ public class FreeBoardCommentService {
         return ResponseEntity.ok(HttpStatus.CREATED);
     }
 
-    public List<FreeBoardCommentEntity> getCommentByPostId(Integer postId) {
+    public List<CommentOutputDTO> getCommentByPostId(Integer postId) {
         List<FreeBoardCommentEntity> comments = freeBoardCommentRepo.findByPostIdAndDepth(postId,COMMENT_DEPTH);
-        List<FreeBoardCommentEntity> resultCommentList = new ArrayList<>();
+        List<CommentOutputDTO> resultCommentList = new ArrayList<>();
+        AccountEntity user = UserUtils.getUserEntity();
 
         Comparator<FreeBoardCommentEntity> comparator = Comparator.comparing(FreeBoardCommentEntity::getCreatedAt);
         comparator = comparator.thenComparingInt(FreeBoardCommentEntity::getBundleId);
         comments.sort(comparator);
 
         for(FreeBoardCommentEntity commentEntity : comments) {
-            List<FreeBoardCommentEntity> commentsOfComment = freeBoardCommentRepo.findByBundleIdAndDepth(commentEntity.getId(),COMMENT_OF_COMMENT_DEPTH);
-            resultCommentList.add(commentEntity);
+            List<FreeBoardCommentEntity> childCommentList = freeBoardCommentRepo.findByBundleIdAndDepth(commentEntity.getId(), CHILD_COMMENT_DEPTH);
 
-            if(commentsOfComment.isEmpty()) continue;
+            resultCommentList.add(new CommentOutputDTO(commentEntity, user.getNickname()));
 
-            for(int i = 0; i < commentsOfComment.size(); i++) {
+            if(childCommentList.isEmpty()) continue;
+
+            for(int i = 0; i < childCommentList.size(); i++) {
                 if(i >= COMMENT_MAX) break;
-                resultCommentList.add(commentsOfComment.get(i));
+                resultCommentList.add(new CommentOutputDTO(childCommentList.get(i), user.getNickname()));
             }
         }
 
         return resultCommentList;
     }
 
-    public List<FreeBoardCommentEntity> getAllCommentByPostId(Integer postId, Integer commentId) {
+    public List<CommentOutputDTO> getAllCommentByPostId(Integer postId, Integer commentId) {
         FreeBoardCommentEntity originalComment = freeBoardCommentRepo.findByPostIdAndDepth(postId,COMMENT_DEPTH)
                 .stream().filter(freeBoardCommentEntity -> freeBoardCommentEntity.getId().equals(commentId)).findFirst()
                 .orElseThrow(() -> new NotFoundException(COMMENT_NOT_FOUND));
-        List<FreeBoardCommentEntity> commentsOfComment = freeBoardCommentRepo.findByBundleIdAndDepth(originalComment.getId(),COMMENT_OF_COMMENT_DEPTH);
-        List<FreeBoardCommentEntity> resultCommentList = new ArrayList<>();
+        List<FreeBoardCommentEntity> childCommentList = freeBoardCommentRepo.findByBundleIdAndDepth(originalComment.getId(), CHILD_COMMENT_DEPTH);
+        List<CommentOutputDTO> resultCommentList = new ArrayList<>();
+        AccountEntity user = UserUtils.getUserEntity();
 
-        resultCommentList.add(originalComment);
+        resultCommentList.add(new CommentOutputDTO(originalComment, user.getNickname()));
 
-        commentsOfComment.forEach(bundle -> {
-            resultCommentList.add(bundle);
+        childCommentList.forEach(bundle -> {
+            resultCommentList.add(new CommentOutputDTO(bundle, user.getNickname()));
         });
 
         return resultCommentList;

--- a/src/main/java/com/springboot/intelllij/utils/UserUtils.java
+++ b/src/main/java/com/springboot/intelllij/utils/UserUtils.java
@@ -1,0 +1,36 @@
+package com.springboot.intelllij.utils;
+
+import com.springboot.intelllij.domain.AccountEntity;
+import com.springboot.intelllij.exceptions.NotFoundException;
+import com.springboot.intelllij.repository.AccountRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+
+import static com.springboot.intelllij.exceptions.EntityNotFoundExceptionEnum.USER_NOT_FOUND;
+
+@Component
+public class UserUtils {
+
+    private static AccountRepository accountRepo;
+
+    @Autowired
+    private AccountRepository initAccountRepo;
+
+    @PostConstruct
+    private void setInitAccountRepo() {
+        accountRepo = this.initAccountRepo;
+    }
+
+    public static AccountEntity getUserEntity() {
+        AccountEntity user = accountRepo.findById(getUserStringFromSecurityContextHolder()).orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
+        return user;
+    }
+
+    public static String getUserStringFromSecurityContextHolder() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return principal.toString();
+    }
+}


### PR DESCRIPTION
fix https://github.com/wanna-go-home/Issue/issues/84

- Comment 관련 반환 API에 nickName 정보 추가
    * 기존 CommentDTO -> CommentInputDTO로 이름 변경
    * 반환을 위해 Comment 정보 + 닉네임 을가진 CommentOutputDTO추가
    * CommentOutputDTO를 CommentBaseEntity 하위 클래스로 둠으로써 속성 그대로 사용
    * CommentBaseEntity에 복사 생성자 추가

- 반복되는 Account 관련 작업을 처리할 AccountUtils 추가
    * userName String 가져오는 메서드
    * userEntity를 가져오는 메서드