### PR TITLE
[Hotfix] Comment id null

### DIFF
--- a/src/main/java/com/springboot/intelllij/domain/CommentBaseEntity.java
+++ b/src/main/java/com/springboot/intelllij/domain/CommentBaseEntity.java
@@ -46,6 +46,7 @@ public class CommentBaseEntity extends BaseEntity {
     }
 
     public CommentBaseEntity(CommentBaseEntity commentBase) {
+        this.setId(commentBase.getId());
         this.email = commentBase.getEmail();
         this.postId = commentBase.getPostId();
         this.content = commentBase.getContent();


### PR DESCRIPTION
복사생성자 만들면서 id복사하는게 빠져있었음