### PR TITLE
Account pk

### DIFF
--- a/src/main/java/com/springboot/intelllij/config/CustomAuthenticationFilter.java
+++ b/src/main/java/com/springboot/intelllij/config/CustomAuthenticationFilter.java
@@ -28,7 +28,7 @@ public class CustomAuthenticationFilter extends UsernamePasswordAuthenticationFi
         String body = request.getReader().lines().collect(Collectors.joining(System.lineSeparator()));
         Map<String,String> jsonMap = new Gson().fromJson(body,HashMap.class);
         authRequest = new UsernamePasswordAuthenticationToken(jsonMap.get("account"), jsonMap.get("pw"));
-        setDetails(request,authRequest);
+        setDetails(request, authRequest);
         return this.getAuthenticationManager().authenticate(authRequest);
     }
 }

--- a/src/main/java/com/springboot/intelllij/config/CustomAuthenticationProvider.java
+++ b/src/main/java/com/springboot/intelllij/config/CustomAuthenticationProvider.java
@@ -24,11 +24,11 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
     @Override
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
         UsernamePasswordAuthenticationToken token = (UsernamePasswordAuthenticationToken)authentication;
-        String userName = token.getName();
+        String userEmail = token.getName();
         String userPw = (String)token.getCredentials();
-        AccountEntity account = accountRepository.findByAccountEmail(userName).orElseThrow(() -> new IllegalArgumentException(userName + " not exist"));
+        AccountEntity account = accountRepository.findByAccountEmail(userEmail).orElseThrow(() -> new IllegalArgumentException(userEmail + " not exist"));
         if(!passwordEncoder.matches(userPw, account.getAccountPw())) {
-            throw new BadCredentialsException(userName + " Invalid password");
+            throw new BadCredentialsException(userEmail + " Invalid password");
         }
         UsernamePasswordAuthenticationToken tokenWithDetails = new UsernamePasswordAuthenticationToken(
                 account, userPw

--- a/src/main/java/com/springboot/intelllij/config/CustomAuthenticationProvider.java
+++ b/src/main/java/com/springboot/intelllij/config/CustomAuthenticationProvider.java
@@ -26,12 +26,15 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
         UsernamePasswordAuthenticationToken token = (UsernamePasswordAuthenticationToken)authentication;
         String userName = token.getName();
         String userPw = (String)token.getCredentials();
-        AccountEntity account = accountRepository.findById(userName).orElseThrow(() -> new IllegalArgumentException(userName + " not exist"));
-        if(!passwordEncoder.matches(userPw,account.getAccountPw())) {
+        AccountEntity account = accountRepository.findByAccountEmail(userName).orElseThrow(() -> new IllegalArgumentException(userName + " not exist"));
+        if(!passwordEncoder.matches(userPw, account.getAccountPw())) {
             throw new BadCredentialsException(userName + " Invalid password");
         }
-
-        return new UsernamePasswordAuthenticationToken(account, userPw);
+        UsernamePasswordAuthenticationToken tokenWithDetails = new UsernamePasswordAuthenticationToken(
+                account, userPw
+        );
+        tokenWithDetails.setDetails(account);
+        return tokenWithDetails;
     }
 
     @Override

--- a/src/main/java/com/springboot/intelllij/config/JwtInterceptor.java
+++ b/src/main/java/com/springboot/intelllij/config/JwtInterceptor.java
@@ -3,7 +3,6 @@ package com.springboot.intelllij.config;
 import com.springboot.intelllij.constant.AuthConstant;
 import com.springboot.intelllij.utils.TokenUtils;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -20,7 +19,11 @@ public class JwtInterceptor implements HandlerInterceptor {
             if(handler != null) {
                 String token = TokenUtils.getTokenFromHeader(header);
                 if(TokenUtils.isValidToken(token)) {
-                    SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(TokenUtils.getUserAccount(token),"test"));
+                    String userEmail = TokenUtils.getUserAccount(token);
+                    Integer userId = TokenUtils.getUserId(token);
+                    UsernamePasswordAuthenticationToken claimedToken = new UsernamePasswordAuthenticationToken(userEmail, "test");
+                    claimedToken.setDetails(userId);
+                    SecurityContextHolder.getContext().setAuthentication(claimedToken);
                     return true;
                 }
             }

--- a/src/main/java/com/springboot/intelllij/domain/AccountEntity.java
+++ b/src/main/java/com/springboot/intelllij/domain/AccountEntity.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.*;
 
@@ -12,6 +14,8 @@ import javax.persistence.*;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@DynamicInsert
+@DynamicUpdate
 @Table(name = "account")
 public class AccountEntity {
 
@@ -31,4 +35,7 @@ public class AccountEntity {
 
     @Column(name = "phone_num")
     private String phoneNum;
+
+    @Column(name = "active")
+    private boolean active;
 }

--- a/src/main/java/com/springboot/intelllij/domain/AccountEntity.java
+++ b/src/main/java/com/springboot/intelllij/domain/AccountEntity.java
@@ -37,5 +37,5 @@ public class AccountEntity {
     private String phoneNum;
 
     @Column(name = "active")
-    private boolean active;
+    private boolean active = true;
 }

--- a/src/main/java/com/springboot/intelllij/domain/AccountEntity.java
+++ b/src/main/java/com/springboot/intelllij/domain/AccountEntity.java
@@ -5,10 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 @Entity
 @Getter
@@ -19,13 +16,17 @@ import javax.persistence.Table;
 public class AccountEntity {
 
     @Id
-    @Column(name = "account_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Integer id;
+
+    @Column(name = "account_email")
     private String accountEmail;
 
     @Column(name = "account_pw")
     private String accountPw;
 
-    @Column(name = "name")
+    @Column(name = "nickname")
     private String nickname;
 
     @Column(name = "phone_num")

--- a/src/main/java/com/springboot/intelllij/domain/BoardBaseEntity.java
+++ b/src/main/java/com/springboot/intelllij/domain/BoardBaseEntity.java
@@ -7,7 +7,6 @@ import lombok.Setter;
 
 import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 @MappedSuperclass
@@ -16,7 +15,7 @@ import java.time.ZonedDateTime;
 @NoArgsConstructor
 public class BoardBaseEntity extends BaseEntity {
     @Column(name = "account_id")
-    private String email;
+    private Integer accountId;
 
     @Column(name = "title")
     private String title;
@@ -25,20 +24,20 @@ public class BoardBaseEntity extends BaseEntity {
     private String content;
 
     @Column(name = "view_cnt")
-    private Integer viewCnt = 0;
+    private Integer viewCnt;
 
     @Column(name = "like_cnt")
-    private Integer likeCnt = 0;
+    private Integer likeCnt;
 
     @Column(name = "reply_cnt")
-    private Integer replyCnt = 0;
+    private Integer replyCnt;
 
     @Column(name = "created_at")
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-    private ZonedDateTime createdAt = ZonedDateTime.now(ZoneId.of("UTC"));
+    private ZonedDateTime createdAt;
 
-    public BoardBaseEntity(String email, String title, String content) {
-        this.email = email;
+    public BoardBaseEntity(Integer accountId, String title, String content) {
+        this.accountId = accountId;
         this.title = title;
         this.content = content;
     }

--- a/src/main/java/com/springboot/intelllij/domain/CommentBaseEntity.java
+++ b/src/main/java/com/springboot/intelllij/domain/CommentBaseEntity.java
@@ -6,7 +6,6 @@ import lombok.Setter;
 
 import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 @MappedSuperclass
@@ -14,7 +13,7 @@ import java.time.ZonedDateTime;
 @Setter
 public class CommentBaseEntity extends BaseEntity {
     @Column(name = "account_id")
-    private String email;
+    private Integer accountId;
 
     @Column(name = "post_id")
     private Integer postId;
@@ -23,20 +22,20 @@ public class CommentBaseEntity extends BaseEntity {
     private String content;
 
     @Column(name = "like_cnt")
-    private Integer likeCnt = 0;
+    private Integer likeCnt;
 
     @Column(name = "created_at")
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-    private ZonedDateTime createdAt = ZonedDateTime.now(ZoneId.of("UTC"));
+    private ZonedDateTime createdAt;
 
     @Column(name = "depth")
-    private Integer depth = 0;
+    private Integer depth;
 
     @Column(name = "bundle_id")
     private Integer bundleId;
 
     @Column(name = "bundle_size")
-    private Integer bundleSize = 0;
+    private Integer bundleSize;
 
     public void increaseBundleSize() {
         this.bundleSize++;

--- a/src/main/java/com/springboot/intelllij/domain/CommentBaseEntity.java
+++ b/src/main/java/com/springboot/intelllij/domain/CommentBaseEntity.java
@@ -49,7 +49,7 @@ public class CommentBaseEntity extends BaseEntity {
 
     public CommentBaseEntity(CommentBaseEntity commentBase) {
         this.setId(commentBase.getId());
-        this.email = commentBase.getEmail();
+        this.accountId = commentBase.getAccountId();
         this.postId = commentBase.getPostId();
         this.content = commentBase.getContent();
         this.likeCnt = commentBase.getLikeCnt();

--- a/src/main/java/com/springboot/intelllij/domain/FreeBoardCommentEntity.java
+++ b/src/main/java/com/springboot/intelllij/domain/FreeBoardCommentEntity.java
@@ -2,8 +2,9 @@ package com.springboot.intelllij.domain;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 
@@ -11,6 +12,7 @@ import javax.persistence.Table;
 @Getter
 @Setter
 @Table(name = "free_board_comment")
+@DynamicUpdate
+@DynamicInsert
 public class FreeBoardCommentEntity extends CommentBaseEntity {
-
 }

--- a/src/main/java/com/springboot/intelllij/domain/FreeBoardEntity.java
+++ b/src/main/java/com/springboot/intelllij/domain/FreeBoardEntity.java
@@ -2,6 +2,8 @@ package com.springboot.intelllij.domain;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.Entity;
 import javax.persistence.Table;
@@ -10,5 +12,7 @@ import javax.persistence.Table;
 @Getter
 @Setter
 @Table(name = "free_board")
+@DynamicUpdate
+@DynamicInsert
 public class FreeBoardEntity extends BoardBaseEntity {
 }

--- a/src/main/java/com/springboot/intelllij/domain/FreeBoardViewEntity.java
+++ b/src/main/java/com/springboot/intelllij/domain/FreeBoardViewEntity.java
@@ -2,6 +2,7 @@ package com.springboot.intelllij.domain;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -11,7 +12,8 @@ import javax.persistence.Table;
 @Setter
 @Entity
 @Table(name = "free_board_view")
+@DynamicUpdate
 public class FreeBoardViewEntity extends BoardBaseEntity {
-    @Column(name = "name")
+    @Column(name = "nickname")
     private String nickname;
 }

--- a/src/main/java/com/springboot/intelllij/domain/ReviewBoardCommentEntity.java
+++ b/src/main/java/com/springboot/intelllij/domain/ReviewBoardCommentEntity.java
@@ -2,6 +2,8 @@ package com.springboot.intelllij.domain;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.Entity;
 import javax.persistence.Table;
@@ -10,6 +12,8 @@ import javax.persistence.Table;
 @Getter
 @Setter
 @Table (name = "review_board_comment")
+@DynamicUpdate
+@DynamicInsert
 public class ReviewBoardCommentEntity extends CommentBaseEntity {
 }
 

--- a/src/main/java/com/springboot/intelllij/domain/ReviewBoardEntity.java
+++ b/src/main/java/com/springboot/intelllij/domain/ReviewBoardEntity.java
@@ -3,6 +3,8 @@ package com.springboot.intelllij.domain;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -13,12 +15,14 @@ import javax.persistence.Table;
 @Setter
 @NoArgsConstructor
 @Table(name = "review_board")
+@DynamicUpdate
+@DynamicInsert
 public class ReviewBoardEntity extends BoardBaseEntity {
     @Column(name = "lens_id")
     private Integer lensId;
 
-    public ReviewBoardEntity(ReviewBoardDto reviewBoardDto, String account) {
-        super(account,reviewBoardDto.getTitle(), reviewBoardDto.getContent());
+    public ReviewBoardEntity(ReviewBoardDto reviewBoardDto, Integer accountId) {
+        super(accountId, reviewBoardDto.getTitle(), reviewBoardDto.getContent());
         this.lensId = reviewBoardDto.getLensId();
     }
 }

--- a/src/main/java/com/springboot/intelllij/domain/ReviewBoardViewEntity.java
+++ b/src/main/java/com/springboot/intelllij/domain/ReviewBoardViewEntity.java
@@ -21,7 +21,7 @@ public class ReviewBoardViewEntity extends BoardBaseEntity {
     private Integer lensId;
 
     public ReviewBoardViewEntity(ReviewBoardViewEntity reviewBoardEntity) {
-        this.setEmail(reviewBoardEntity.getEmail());
+        this.setAccountId(reviewBoardEntity.getAccountId());
         this.setTitle(reviewBoardEntity.getTitle());
         this.setContent(reviewBoardEntity.getContent());
         this.setViewCnt(reviewBoardEntity.getViewCnt());

--- a/src/main/java/com/springboot/intelllij/domain/ReviewBoardViewEntity.java
+++ b/src/main/java/com/springboot/intelllij/domain/ReviewBoardViewEntity.java
@@ -12,7 +12,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "review_board_view")
 public class ReviewBoardViewEntity extends BoardBaseEntity {
-    @Column(name = "name")
+    @Column(name = "nickname")
     private String nickname;
 
     @Column(name = "lens_id")

--- a/src/main/java/com/springboot/intelllij/domain/ReviewBoardViewEntity.java
+++ b/src/main/java/com/springboot/intelllij/domain/ReviewBoardViewEntity.java
@@ -21,6 +21,7 @@ public class ReviewBoardViewEntity extends BoardBaseEntity {
     private Integer lensId;
 
     public ReviewBoardViewEntity(ReviewBoardViewEntity reviewBoardEntity) {
+        this.setId(reviewBoardEntity.getId());
         this.setAccountId(reviewBoardEntity.getAccountId());
         this.setTitle(reviewBoardEntity.getTitle());
         this.setContent(reviewBoardEntity.getContent());

--- a/src/main/java/com/springboot/intelllij/domain/UserInfoDTO.java
+++ b/src/main/java/com/springboot/intelllij/domain/UserInfoDTO.java
@@ -15,6 +15,6 @@ public class UserInfoDTO {
     private int reviewCommentCount;
     private int freeCommentCount;
     private int likeCount;
-    private String email;
+    private int accountId;
     private String nickName;
 }

--- a/src/main/java/com/springboot/intelllij/repository/AccountRepository.java
+++ b/src/main/java/com/springboot/intelllij/repository/AccountRepository.java
@@ -4,8 +4,11 @@ import com.springboot.intelllij.domain.AccountEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
-public interface AccountRepository extends JpaRepository<AccountEntity, String> {
+public interface AccountRepository extends JpaRepository<AccountEntity, Integer> {
+
+    Optional<AccountEntity> findByAccountEmail(String email);
 
     List<AccountEntity> findByNickname(String nickname);
 

--- a/src/main/java/com/springboot/intelllij/repository/AccountRepository.java
+++ b/src/main/java/com/springboot/intelllij/repository/AccountRepository.java
@@ -2,12 +2,14 @@ package com.springboot.intelllij.repository;
 
 import com.springboot.intelllij.domain.AccountEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface AccountRepository extends JpaRepository<AccountEntity, Integer> {
-
     Optional<AccountEntity> findByAccountEmail(String email);
 
     List<AccountEntity> findByNickname(String nickname);

--- a/src/main/java/com/springboot/intelllij/repository/AccountRepository.java
+++ b/src/main/java/com/springboot/intelllij/repository/AccountRepository.java
@@ -2,9 +2,6 @@ package com.springboot.intelllij.repository;
 
 import com.springboot.intelllij.domain.AccountEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/com/springboot/intelllij/repository/FreeBoardCommentRepository.java
+++ b/src/main/java/com/springboot/intelllij/repository/FreeBoardCommentRepository.java
@@ -12,7 +12,7 @@ public interface FreeBoardCommentRepository extends JpaRepository<FreeBoardComme
 
     List<FreeBoardCommentEntity> findByBundleIdAndDepth(Integer bundleId, Integer depth);
 
-    List<FreeBoardCommentEntity> findByEmail(String email);
+    List<FreeBoardCommentEntity> findByAccountId(Integer accountId);
 
     void deleteByPostId(Integer postId);
 }

--- a/src/main/java/com/springboot/intelllij/repository/FreeBoardPreviewRepository.java
+++ b/src/main/java/com/springboot/intelllij/repository/FreeBoardPreviewRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface FreeBoardPreviewRepository extends JpaRepository<FreeBoardViewEntity, Integer> {
 
-    List<FreeBoardViewEntity> findByEmail(String email);
+    List<FreeBoardViewEntity> findByAccountId(Integer accountId);
 }

--- a/src/main/java/com/springboot/intelllij/repository/FreeBoardRepository.java
+++ b/src/main/java/com/springboot/intelllij/repository/FreeBoardRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface FreeBoardRepository extends JpaRepository<FreeBoardEntity, Integer> {
-    List<FreeBoardEntity> findByEmail(String email);
+    List<FreeBoardEntity> findByAccountId(Integer accountId);
 
     @Modifying
     @Query("update FreeBoardEntity e set e.title = :title, e.content = :content where e.id = :id")

--- a/src/main/java/com/springboot/intelllij/repository/ReviewBoardCommentRepository.java
+++ b/src/main/java/com/springboot/intelllij/repository/ReviewBoardCommentRepository.java
@@ -8,7 +8,7 @@ import java.util.List;
 public interface ReviewBoardCommentRepository extends JpaRepository<ReviewBoardCommentEntity, Integer> {
     List<ReviewBoardCommentEntity> findByPostId(Integer integer);
 
-    List<ReviewBoardCommentEntity> findByEmail(String email);
+    List<ReviewBoardCommentEntity> findByAccountId(Integer accountId);
 
     List<ReviewBoardCommentEntity> findByPostIdAndDepth(Integer postId, Integer depth);
 

--- a/src/main/java/com/springboot/intelllij/repository/ReviewBoardPreviewRepository.java
+++ b/src/main/java/com/springboot/intelllij/repository/ReviewBoardPreviewRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface ReviewBoardPreviewRepository extends JpaRepository<ReviewBoardViewEntity, Integer> {
 
-    List<ReviewBoardViewEntity> findByEmail(String email);
+    List<ReviewBoardViewEntity> findByAccountId(Integer AccountId);
 }

--- a/src/main/java/com/springboot/intelllij/repository/ReviewBoardRepository.java
+++ b/src/main/java/com/springboot/intelllij/repository/ReviewBoardRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface ReviewBoardRepository extends JpaRepository<ReviewBoardEntity, Integer> {
-    List<ReviewBoardEntity> findByEmail(String email);
+    List<ReviewBoardEntity> findByAccountId(Integer accountId);
 
     @Modifying
     @Query("update ReviewBoardEntity e set e.title = :title, e.content = :content where e.id = :id")

--- a/src/main/java/com/springboot/intelllij/services/AccountService.java
+++ b/src/main/java/com/springboot/intelllij/services/AccountService.java
@@ -36,14 +36,13 @@ public class AccountService {
     public List<AccountEntity> getAllUsers() { return userRepo.findAll(); }
 
     public ResponseEntity deleteUser() {
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String user = principal.toString();
-        userRepo.deleteById(user);
+        Integer accountId = (Integer) SecurityContextHolder.getContext().getAuthentication().getDetails();
+        userRepo.deleteById(accountId);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 
-    public ResponseEntity checkId(String id) {
-        if (userRepo.findById(id).isPresent() || !StringValidationUtils.isValidEmail(id)) {
+    public ResponseEntity checkId(String email) {
+        if (userRepo.findByAccountEmail(email).isPresent() || !StringValidationUtils.isValidEmail(email)) {
             return ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE).build();
         }
         return ResponseEntity.status(HttpStatus.OK).build();
@@ -79,13 +78,12 @@ public class AccountService {
 
     public UserInfoDTO getUserInfo() {
         UserInfoDTO userInfo = new UserInfoDTO();
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String user = principal.toString();
-        AccountEntity account = userRepo.findById(user).orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
-        List<ReviewBoardEntity> reviewBoardEntities = reviewRepo.findByEmail(user);
-        List<FreeBoardEntity> freeBoardEntities = freeRepo.findByEmail(user);
-        List<ReviewBoardCommentEntity> reviewBoardCommentEntities = reviewCOmmentRepo.findByEmail(user);
-        List<FreeBoardCommentEntity> freeBoardCommentEntities = freeCommentRepo.findByEmail(user);
+        Integer accountId = (Integer)SecurityContextHolder.getContext().getAuthentication().getDetails();
+        AccountEntity account = userRepo.findById(accountId).orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
+        List<ReviewBoardEntity> reviewBoardEntities = reviewRepo.findByAccountId(accountId);
+        List<FreeBoardEntity> freeBoardEntities = freeRepo.findByAccountId(accountId);
+        List<ReviewBoardCommentEntity> reviewBoardCommentEntities = reviewCOmmentRepo.findByAccountId(accountId);
+        List<FreeBoardCommentEntity> freeBoardCommentEntities = freeCommentRepo.findByAccountId(accountId);
 
         int likeCount = 0;
         likeCount += reviewBoardEntities.stream().mapToInt(reviewBoardEntity -> reviewBoardEntity.getLikeCnt()).sum();

--- a/src/main/java/com/springboot/intelllij/services/AccountService.java
+++ b/src/main/java/com/springboot/intelllij/services/AccountService.java
@@ -37,7 +37,14 @@ public class AccountService {
 
     public ResponseEntity deleteUser() {
         Integer accountId = (Integer) SecurityContextHolder.getContext().getAuthentication().getDetails();
-        userRepo.deleteById(accountId);
+        AccountEntity accountEntity = userRepo.findById(accountId).orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
+
+        accountEntity.setAccountEmail(null);
+        accountEntity.setAccountPw(null);
+        accountEntity.setPhoneNum(null);
+        accountEntity.setActive(false);
+        userRepo.save(accountEntity);
+
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 

--- a/src/main/java/com/springboot/intelllij/services/AccountService.java
+++ b/src/main/java/com/springboot/intelllij/services/AccountService.java
@@ -84,11 +84,12 @@ public class AccountService {
 
     public UserInfoDTO getUserInfo() {
         UserInfoDTO userInfo = new UserInfoDTO();
-        Integer accountId = UserUtils.getUserIdFromSecurityContextHolder();
+        AccountEntity account = UserUtils.getUserEntity();
+        int accountId = account.getId();
 
         List<ReviewBoardEntity> reviewBoardEntities = reviewRepo.findByAccountId(accountId);
         List<FreeBoardEntity> freeBoardEntities = freeRepo.findByAccountId(accountId);
-        List<ReviewBoardCommentEntity> reviewBoardCommentEntities = reviewCOmmentRepo.findByAccountId(accountId);
+        List<ReviewBoardCommentEntity> reviewBoardCommentEntities = reviewCommentRepo.findByAccountId(accountId);
         List<FreeBoardCommentEntity> freeBoardCommentEntities = freeCommentRepo.findByAccountId(accountId);
 
         int likeCount = 0;
@@ -108,10 +109,9 @@ public class AccountService {
     }
 
     public List<CommentBaseEntity> getUserArticleComments() {
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String user = principal.toString();
+        int accountId = UserUtils.getUserIdFromSecurityContextHolder();
         List<CommentBaseEntity> result = new ArrayList<>();
-        List<FreeBoardCommentEntity> freeboardComments = freeCommentRepo.findByEmail(user);
+        List<FreeBoardCommentEntity> freeboardComments = freeCommentRepo.findByAccountId(accountId);
 
         result.addAll(freeboardComments);
         result.sort(new CommentComparator());
@@ -120,10 +120,9 @@ public class AccountService {
     }
 
     public List<CommentBaseEntity> getUserReviewComments() {
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String user = principal.toString();
+        int accountId = UserUtils.getUserIdFromSecurityContextHolder();
         List<CommentBaseEntity> result = new ArrayList<>();
-        List<ReviewBoardCommentEntity> reviewBoarcComments = reviewCommentRepo.findByEmail(user);
+        List<ReviewBoardCommentEntity> reviewBoarcComments = reviewCommentRepo.findByAccountId(accountId);
 
         result.addAll(reviewBoarcComments);
         result.sort(new CommentComparator());

--- a/src/main/java/com/springboot/intelllij/services/FreeBoardPreviewService.java
+++ b/src/main/java/com/springboot/intelllij/services/FreeBoardPreviewService.java
@@ -17,16 +17,13 @@ public class FreeBoardPreviewService {
 
     public List<FreeBoardViewEntity> getAllPreview() {
         List<FreeBoardViewEntity> result = freeBoardPreviewRepo.findAll();
-
         result.sort(new BoardComparator());
-
         return result;
     }
 
     public List<FreeBoardViewEntity> getMyAllPreview() {
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String user = principal.toString();
-        List<FreeBoardViewEntity> result = freeBoardPreviewRepo.findByEmail(user);
+        Integer accountId = (Integer)SecurityContextHolder.getContext().getAuthentication().getDetails();
+        List<FreeBoardViewEntity> result = freeBoardPreviewRepo.findByAccountId(accountId);
 
         result.sort(new BoardComparator());
 

--- a/src/main/java/com/springboot/intelllij/services/FreeBoardService.java
+++ b/src/main/java/com/springboot/intelllij/services/FreeBoardService.java
@@ -16,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.ZonedDateTime;
 import java.util.List;
-import java.util.Optional;
 
 import static com.springboot.intelllij.exceptions.EntityNotFoundExceptionEnum.BOARD_NOT_FOUND;
 import static com.springboot.intelllij.exceptions.EntityNotFoundExceptionEnum.POST_NOT_FOUND;
@@ -34,11 +33,10 @@ public class FreeBoardService {
     public List<FreeBoardEntity> getAllPosts() { return freeBoardRepo.findAll(); }
 
     public ResponseEntity addPostToFreeBoard(BoardUpdateDTO freeBoard) {
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String user = principal.toString();
-        FreeBoardEntity entity = new FreeBoardEntity();
+        Integer accountId = (Integer)SecurityContextHolder.getContext().getAuthentication().getDetails();
 
-        entity.setEmail(user);
+        FreeBoardEntity entity = new FreeBoardEntity();
+        entity.setAccountId(accountId);
         entity.setContent(freeBoard.getContent());
         entity.setCreatedAt(ZonedDateTime.now());
         entity.setTitle(freeBoard.getTitle());

--- a/src/main/java/com/springboot/intelllij/services/ReviewBoardCommentService.java
+++ b/src/main/java/com/springboot/intelllij/services/ReviewBoardCommentService.java
@@ -1,7 +1,6 @@
 package com.springboot.intelllij.services;
 
 import com.springboot.intelllij.domain.CommentDTO;
-import com.springboot.intelllij.domain.FreeBoardCommentEntity;
 import com.springboot.intelllij.domain.ReviewBoardCommentEntity;
 import com.springboot.intelllij.domain.ReviewBoardEntity;
 import com.springboot.intelllij.exceptions.NotFoundException;
@@ -36,15 +35,13 @@ public class ReviewBoardCommentService {
 
     public ResponseEntity post(Integer postId, CommentDTO comment) {
         ReviewBoardCommentEntity commentEntity = new ReviewBoardCommentEntity();
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String user = principal.toString();
         ReviewBoardEntity review = reviewBoardRepo.findById(postId).orElseThrow(() -> new NotFoundException(POST_NOT_FOUND));
 
+        Integer accountId = (Integer)SecurityContextHolder.getContext().getAuthentication().getDetails();
         commentEntity.setContent(comment.getContent());
         commentEntity.setPostId(postId);
-
         commentEntity.setCreatedAt(ZonedDateTime.now());
-        commentEntity.setEmail(user);
+        commentEntity.setAccountId(accountId);
 
         if(comment.getBundleId() != null) {
             commentEntity.setBundleId(comment.getBundleId());

--- a/src/main/java/com/springboot/intelllij/services/ReviewBoardPreviewService.java
+++ b/src/main/java/com/springboot/intelllij/services/ReviewBoardPreviewService.java
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
-import java.util.Comparator;
 import java.util.List;
 
 @Service
@@ -25,9 +24,8 @@ public class ReviewBoardPreviewService {
     }
 
     public List<ReviewBoardViewEntity> getMyAllPreview() {
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String user = principal.toString();
-        List<ReviewBoardViewEntity> result = reviewBoardPreviewRepo.findByEmail(user);
+        Integer accountId = (Integer)SecurityContextHolder.getContext().getAuthentication().getDetails();
+        List<ReviewBoardViewEntity> result = reviewBoardPreviewRepo.findByAccountId(accountId);
 
         result.sort(new BoardComparator());
 

--- a/src/main/java/com/springboot/intelllij/services/ReviewBoardService.java
+++ b/src/main/java/com/springboot/intelllij/services/ReviewBoardService.java
@@ -15,8 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static com.springboot.intelllij.exceptions.EntityNotFoundExceptionEnum.BOARD_NOT_FOUND;
-import static com.springboot.intelllij.exceptions.EntityNotFoundExceptionEnum.POST_NOT_FOUND;
+import static com.springboot.intelllij.exceptions.EntityNotFoundExceptionEnum.*;
 
 @Service
 public class ReviewBoardService {

--- a/src/main/java/com/springboot/intelllij/services/ReviewBoardService.java
+++ b/src/main/java/com/springboot/intelllij/services/ReviewBoardService.java
@@ -40,7 +40,7 @@ public class ReviewBoardService {
         LensEntity lensInfo = lensRepository.findById(reviewBoardViewEntity.getLensId())
                 .orElseThrow(()-> new NotFoundException(LENS_NOT_FOUND));
 
-        return new ReviewBoardViewWithLensInfoEntity(reviewBoardViewEntity,lensInfo);
+        return new ReviewBoardViewWithLensInfoEntity(reviewBoardViewEntity, lensInfo);
     }
 
     public ResponseEntity addPostToReviewBoard(ReviewBoardDto reviewBoardDto) {

--- a/src/main/java/com/springboot/intelllij/services/ReviewBoardService.java
+++ b/src/main/java/com/springboot/intelllij/services/ReviewBoardService.java
@@ -16,7 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static com.springboot.intelllij.exceptions.EntityNotFoundExceptionEnum.*;
+import static com.springboot.intelllij.exceptions.EntityNotFoundExceptionEnum.BOARD_NOT_FOUND;
+import static com.springboot.intelllij.exceptions.EntityNotFoundExceptionEnum.POST_NOT_FOUND;
 
 @Service
 public class ReviewBoardService {
@@ -40,8 +41,8 @@ public class ReviewBoardService {
     }
 
     public ResponseEntity addPostToReviewBoard(ReviewBoardDto reviewBoardDto) {
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        ReviewBoardEntity reviewBoard = new ReviewBoardEntity(reviewBoardDto,principal.toString());
+        Integer accountId = (Integer)SecurityContextHolder.getContext().getAuthentication().getDetails();
+        ReviewBoardEntity reviewBoard = new ReviewBoardEntity(reviewBoardDto, accountId);
         reviewBoardRepo.save(reviewBoard);
         return ResponseEntity.ok(HttpStatus.CREATED);
     }

--- a/src/main/java/com/springboot/intelllij/utils/TokenUtils.java
+++ b/src/main/java/com/springboot/intelllij/utils/TokenUtils.java
@@ -49,7 +49,12 @@ public class TokenUtils {
 
     public static String getUserAccount(String token) {
         Claims claims = getClaimsFromToken(token);
-        return claims.get("id").toString();
+        return claims.get("email").toString();
+    }
+
+    public static Integer getUserId(String token) {
+        Claims claims = getClaimsFromToken(token);
+        return Integer.parseInt(claims.get("id").toString());
     }
 
     private static Claims getClaimsFromToken(String token) {
@@ -66,9 +71,10 @@ public class TokenUtils {
     }
 
     private Map<String, Object> createClaims(AccountEntity account) {
-        Map<String,Object> claims = new HashMap<>();
-        claims.put("id",account.getAccountEmail());
-        claims.put("nickname",account.getNickname());
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("email", account.getAccountEmail());
+        claims.put("nickname", account.getNickname());
+        claims.put("id", account.getId());
         return claims;
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,7 +8,7 @@ spring.datasource.sql-script-encoding=utf-8
 spring.datasource.initialization-mode=always
 spring.datasource.platform=postgres
 spring.datasource.driverClassName=net.sf.log4jdbc.sql.jdbcapi.DriverSpy
-spring.datasource.url=jdbc:log4jdbc:postgresql://go-home.caa0s7nh3dxo.ap-northeast-2.rds.amazonaws.com:5432/test
+spring.datasource.url=jdbc:log4jdbc:postgresql://go-home.caa0s7nh3dxo.ap-northeast-2.rds.amazonaws.com:5432/go_home
 spring.datasource.username=postgres
 spring.datasource.password=wanna-go-home
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,7 +8,7 @@ spring.datasource.sql-script-encoding=utf-8
 spring.datasource.initialization-mode=always
 spring.datasource.platform=postgres
 spring.datasource.driverClassName=net.sf.log4jdbc.sql.jdbcapi.DriverSpy
-spring.datasource.url=jdbc:log4jdbc:postgresql://go-home.caa0s7nh3dxo.ap-northeast-2.rds.amazonaws.com:5432/go_home
+spring.datasource.url=jdbc:log4jdbc:postgresql://go-home.caa0s7nh3dxo.ap-northeast-2.rds.amazonaws.com:5432/test
 spring.datasource.username=postgres
 spring.datasource.password=wanna-go-home
 


### PR DESCRIPTION
- email 이 아닌 auto increment의 integer를 acount entity의 PK로 사용함
- 그래서 모든 account Entity의 PK 부분이 byId에서 byAccountId로 바뀜
- email, pw로 로그인 한 다음에 security context를 통해 id(pk)를 얻어내기 위해 details를 저장함
- account 삭제시에 일단 정보 날리고 active flag false로 바뀌도록 함