### PR TITLE
[Feature] Issue-98 / Fix Account id and add Email

### DIFF
--- a/src/main/java/com/springboot/intelllij/domain/UserInfoDTO.java
+++ b/src/main/java/com/springboot/intelllij/domain/UserInfoDTO.java
@@ -16,5 +16,6 @@ public class UserInfoDTO {
     private int freeCommentCount;
     private int likeCount;
     private int accountId;
+    private String email;
     private String nickName;
 }

--- a/src/main/java/com/springboot/intelllij/services/AccountService.java
+++ b/src/main/java/com/springboot/intelllij/services/AccountService.java
@@ -98,6 +98,8 @@ public class AccountService {
         likeCount += reviewBoardCommentEntities.stream().mapToInt(reviewComment -> reviewComment.getLikeCnt()).sum();
         likeCount += freeBoardCommentEntities.stream().mapToInt(freeComment -> freeComment.getLikeCnt()).sum();
 
+        userInfo.setAccountId(accountId);
+        userInfo.setEmail(account.getAccountEmail());
         userInfo.setFreeCount(freeBoardEntities.size());
         userInfo.setReviewCount(reviewBoardEntities.size());
         userInfo.setFreeCommentCount(freeBoardCommentEntities.size());


### PR DESCRIPTION
fix https://github.com/wanna-go-home/Issue/issues/98
- user/me 에 accountId가 0 인걸 수정
- 어카운트 아이디가 메일에서 걍 int로 바끼면서 발생한 문제인듯
- 그래서 아이디 맞게 넣어주고 메일도 넣어줌~
- result

```json
{
  "reviewCount": 1,
  "freeCount": 1,
  "reviewCommentCount": 0,
  "freeCommentCount": 1,
  "likeCount": 0,
  "accountId": 1,
  "email": "admin@admin.com",
  "nickName": "SuperUser"
}
```