### PR TITLE
[Feature] Issue-78 / API Pagination

### DIFF
--- a/src/main/java/com/springboot/intelllij/controller/FreeBoardController.java
+++ b/src/main/java/com/springboot/intelllij/controller/FreeBoardController.java
@@ -6,6 +6,7 @@ import com.springboot.intelllij.services.FreeBoardCommentService;
 import com.springboot.intelllij.services.FreeBoardPreviewService;
 import com.springboot.intelllij.services.FreeBoardService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -26,7 +27,9 @@ public class FreeBoardController {
     FreeBoardCommentService freeBoardCommentService;
 
     @GetMapping
-    public List<FreeBoardViewEntity>  getFreeBoardPreviews() { return freeBoardPreviewService.getAllPreview(); }
+    public List<FreeBoardViewEntity>  getFreeBoardPreviews(int page, int size) {
+        return freeBoardPreviewService.getAllPreview(PageRequest.of(page,size));
+    }
 
     @GetMapping(value = "/{id}")
     public FreeBoardViewEntity getFreeBoardById(@PathVariable(name = "id") Integer id) {

--- a/src/main/java/com/springboot/intelllij/controller/LensInfoController.java
+++ b/src/main/java/com/springboot/intelllij/controller/LensInfoController.java
@@ -5,6 +5,7 @@ import com.springboot.intelllij.domain.LensEntity;
 import com.springboot.intelllij.domain.LensPreviewEntity;
 import com.springboot.intelllij.services.LensInfoService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -17,7 +18,9 @@ public class LensInfoController {
     LensInfoService lensInfoService;
 
     @GetMapping
-    public List<LensPreviewEntity> getLensesPreview() { return lensInfoService.getLensesPreview(); }
+    public List<LensPreviewEntity> getLensesPreview(int page, int size) {
+        return lensInfoService.getLensesPreview(PageRequest.of(page,size));
+    }
 
     @GetMapping(value = "/{id}")
     public LensEntity getLensInfoById(@PathVariable(name = "id") Integer id) {

--- a/src/main/java/com/springboot/intelllij/controller/ReviewBoardController.java
+++ b/src/main/java/com/springboot/intelllij/controller/ReviewBoardController.java
@@ -6,6 +6,7 @@ import com.springboot.intelllij.services.ReviewBoardCommentService;
 import com.springboot.intelllij.services.ReviewBoardPreviewService;
 import com.springboot.intelllij.services.ReviewBoardService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -26,7 +27,9 @@ public class ReviewBoardController {
     ReviewBoardCommentService reviewBoardCommentService;
 
     @GetMapping
-    public List<ReviewBoardViewEntity> getReviewBoardPreview() { return reviewBoardPreviewService.getAllPreview(); }
+    public List<ReviewBoardViewEntity> getReviewBoardPreview(int page, int size) {
+        return reviewBoardPreviewService.getAllPreview(PageRequest.of(page,size));
+    }
 
     @GetMapping(value = "/{id}")
     public ReviewBoardViewWithLensInfoEntity getReviewBoardById(@PathVariable(name = "id") Integer id) {

--- a/src/main/java/com/springboot/intelllij/services/FreeBoardPreviewService.java
+++ b/src/main/java/com/springboot/intelllij/services/FreeBoardPreviewService.java
@@ -4,9 +4,11 @@ import com.springboot.intelllij.domain.FreeBoardViewEntity;
 import com.springboot.intelllij.repository.FreeBoardPreviewRepository;
 import com.springboot.intelllij.utils.BoardComparator;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -15,9 +17,12 @@ public class FreeBoardPreviewService {
     @Autowired
     FreeBoardPreviewRepository freeBoardPreviewRepo;
 
-    public List<FreeBoardViewEntity> getAllPreview() {
-        List<FreeBoardViewEntity> result = freeBoardPreviewRepo.findAll();
+    public List<FreeBoardViewEntity> getAllPreview(Pageable pageable) {
+        List<FreeBoardViewEntity> result = new ArrayList<>();
+
+        result.addAll(freeBoardPreviewRepo.findAll(pageable).getContent());
         result.sort(new BoardComparator());
+
         return result;
     }
 

--- a/src/main/java/com/springboot/intelllij/services/LensInfoService.java
+++ b/src/main/java/com/springboot/intelllij/services/LensInfoService.java
@@ -7,6 +7,7 @@ import com.springboot.intelllij.exceptions.NotFoundException;
 import com.springboot.intelllij.repository.LensPreviewRepository;
 import com.springboot.intelllij.repository.LensRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -30,5 +31,7 @@ public class LensInfoService {
         return lensRepo.findById(id).orElseThrow(() -> new NotFoundException(LENS_NOT_FOUND));
     }
 
-    public List<LensPreviewEntity> getLensesPreview() { return lensPreviewRepo.findAll(); }
+    public List<LensPreviewEntity> getLensesPreview(Pageable pageable) {
+        return lensPreviewRepo.findAll(pageable).toList();
+    }
 }

--- a/src/main/java/com/springboot/intelllij/services/ReviewBoardPreviewService.java
+++ b/src/main/java/com/springboot/intelllij/services/ReviewBoardPreviewService.java
@@ -4,9 +4,11 @@ import com.springboot.intelllij.domain.ReviewBoardViewEntity;
 import com.springboot.intelllij.repository.ReviewBoardPreviewRepository;
 import com.springboot.intelllij.utils.BoardComparator;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -15,9 +17,10 @@ public class ReviewBoardPreviewService {
     @Autowired
     ReviewBoardPreviewRepository reviewBoardPreviewRepo;
 
-    public List<ReviewBoardViewEntity> getAllPreview() {
-        List<ReviewBoardViewEntity> result = reviewBoardPreviewRepo.findAll();
+    public List<ReviewBoardViewEntity> getAllPreview(Pageable pageable) {
+        List<ReviewBoardViewEntity> result = new ArrayList<>();
 
+        result.addAll(reviewBoardPreviewRepo.findAll(pageable).getContent());
         result.sort(new BoardComparator());
 
         return result;


### PR DESCRIPTION
fix https://github.com/wanna-go-home/Issue/issues/78

- 렌즈 정보 API, 리뷰 전체 API, 아티클 전체 API에 페이지 네이션 적용
![image](https://user-images.githubusercontent.com/11551871/104115945-de31d500-5357-11eb-882f-9591992b828b.png)
![image](https://user-images.githubusercontent.com/11551871/104115955-eb4ec400-5357-11eb-86d3-b6c302c5da07.png)
![image](https://user-images.githubusercontent.com/11551871/104115968-fc97d080-5357-11eb-8107-c92fa239ba70.png)

- 몇번째 페이지를 받아올건지 정하는 page 와, page의 크기를 정하는 size를 인수로 받음